### PR TITLE
[turtle-cli] don't require push notifications cert to build an ios app

### DIFF
--- a/src/bin/commands/build/ios.ts
+++ b/src/bin/commands/build/ios.ts
@@ -23,10 +23,6 @@ export default (program: any, setCommonCommandOptions: any) => {
       '--dist-p12-path <dist.p12>',
       'path to your Distribution Certificate P12 (please provide password as EXPO_IOS_DIST_P12_PASSWORD env variable)'
     )
-    .option(
-      '--push-p12-path <push.p12>',
-      'path to your Push Notification Certificate P12 (please provide password as EXPO_IOS_PUSH_P12_PASSWORD env variable)'
-    )
     .option('--provisioning-profile-path <.mobileprovision>', 'path to your Provisioning Profile')
     .description(
       'Build a standalone IPA for your project, signed and ready for submission to the Apple App Store.'
@@ -64,16 +60,15 @@ const prepareCredentials = async (cmd: any) => {
     return null;
   }
 
-  const { teamId, distP12Path, pushP12Path, provisioningProfilePath } = cmd;
+  const { teamId, distP12Path, provisioningProfilePath } = cmd;
   const certPassword = process.env.EXPO_IOS_DIST_P12_PASSWORD;
-  const pushPassword = process.env.EXPO_IOS_PUSH_P12_PASSWORD;
 
   const credentialsExist =
-    teamId && distP12Path && certPassword && pushP12Path && pushPassword && provisioningProfilePath;
+    teamId && distP12Path && certPassword && provisioningProfilePath;
 
   if (!credentialsExist) {
     throw new ErrorWithCommandHelp(
-      'Please provide all required credentials - Apple Team ID, Distribution Certificate P12 (with password), Push Notification Certificate P12 (with password) and Provisioning Profile'
+      'Please provide all required credentials - Apple Team ID, Distribution Certificate P12 (with password) and Provisioning Profile'
     );
   }
 
@@ -81,8 +76,6 @@ const prepareCredentials = async (cmd: any) => {
     teamId,
     certP12: (await fs.readFile(distP12Path)).toString('base64'),
     certPassword,
-    pushP12: (await fs.readFile(pushP12Path)).toString('base64'),
-    pushPassword,
     provisioningProfile: (await fs.readFile(provisioningProfilePath)).toString('base64'),
   };
 };

--- a/src/builders/ios/index.ts
+++ b/src/builders/ios/index.ts
@@ -1,7 +1,7 @@
-import * as fs from 'fs-extra';
-import * as _ from 'lodash';
-import * as path from 'path';
+import path from 'path';
 
+import fs from 'fs-extra';
+import pick from 'lodash/pick';
 import { ExponentTools } from 'xdl';
 
 import buildArchive from 'turtle/builders/ios/archive';
@@ -59,7 +59,7 @@ async function cleanup(ctx: IContext) {
 }
 
 const getTemporaryDirs = (ctx: IContext) =>
-  Object.values(_.pick(ctx, ['appDir', 'provisioningProfileDir']));
+  Object.values(pick(ctx, ['appDir', 'provisioningProfileDir']));
 
 async function ensureCanBuildSdkVersion(job: IJob) {
   if (config.builder.useLocalWorkingDir) {
@@ -71,7 +71,7 @@ async function ensureCanBuildSdkVersion(job: IJob) {
   }
 
   const targetMajorSdkVersion = ExponentTools.parseSdkMajorVersion(job.sdkVersion || job.manifest.sdkVersion);
-  if (!_.includes(SUPPORTED_SDK_VERSIONS, targetMajorSdkVersion)) {
+  if (!SUPPORTED_SDK_VERSIONS.includes(targetMajorSdkVersion)) {
     throw new Error(`Unsupported SDK Version!`);
   }
 }


### PR DESCRIPTION
# Why

Turtle doesn't need Push Notification Certificate to successfully build an iOS standalone app.

# How

- I deleted `--push-p12-path` parameter from `expo build:ios` command
- I changed the code for credentials validation so that it doesn't require `--push-p12-path` and `EXPO_IOS_PUSH_P12_PASSWORD ` to be set

# Test Plan

Tested locally, `turtle-cli` successfully produced a `.ipa` file.
