### PR TITLE
register turtle version in redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Register Turtle version in Redis
 
 ## [0.5.8] - 2019-02-06
 - Update iOS shell app for SDK 32 (fixes bare notifications [issue](https://github.com/expo/expo/issues/3223)).

--- a/src/jobManager.ts
+++ b/src/jobManager.ts
@@ -1,6 +1,3 @@
-import path from 'path';
-
-import fs from 'fs-extra';
 import _ from 'lodash';
 
 import * as sqs from 'turtle/aws/sqs';
@@ -11,12 +8,10 @@ import { BUILD } from 'turtle/constants/index';
 import logger from 'turtle/logger';
 import * as buildDurationMetric from 'turtle/metrics/buildDuration';
 import * as buildStatusMetric from 'turtle/metrics/buildStatus';
-import { checkShouldExit, setCurrentJobId } from 'turtle/turtleContext';
+import { checkShouldExit, setCurrentJobId, turtleVersion } from 'turtle/turtleContext';
 import { getPriorities } from 'turtle/utils/priorities';
 import * as redis from 'turtle/utils/redis';
 import { sanitizeJob } from 'turtle/validator';
-
-const { version: turtleVersion } = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8'));
 
 function _maybeExit() {
   if (checkShouldExit()) {

--- a/src/turtleContext.ts
+++ b/src/turtleContext.ts
@@ -1,4 +1,9 @@
+import fs from 'fs-extra';
+import path from 'path';
 import config from 'turtle/config';
+
+const { version: turtleVersion } = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8'));
+export { turtleVersion };
 
 let shouldExit = false;
 let currentJobId: string | null = null;


### PR DESCRIPTION
# Why

Checking for reusable builds needs to have access to current turtle version and one available in npm is not always the same as on servers

# How

The version is set under key `turtle:version`

# Test Plan

