### PR TITLE
Log error objects where possible

### DIFF
--- a/src/aws/cloudwatch/index.ts
+++ b/src/aws/cloudwatch/index.ts
@@ -179,7 +179,7 @@ function _pushMetrics(metrics: IMetricsChunk[]) {
   metrics.forEach((metricsChunk) => {
     cloudWatch.putMetricData(metricsChunk, (err) => {
       if (err) {
-        logger.warn({err}, '[cloudwatch]');
+        logger.warn({ err }, '[cloudwatch]');
       }
     });
   });

--- a/src/aws/cloudwatch/index.ts
+++ b/src/aws/cloudwatch/index.ts
@@ -179,7 +179,7 @@ function _pushMetrics(metrics: IMetricsChunk[]) {
   metrics.forEach((metricsChunk) => {
     cloudWatch.putMetricData(metricsChunk, (err) => {
       if (err) {
-        logger.warn('[cloudwatch]', err);
+        logger.warn({err}, '[cloudwatch]');
       }
     });
   });

--- a/src/aws/sqs.ts
+++ b/src/aws/sqs.ts
@@ -36,7 +36,7 @@ export async function receiveMessage(priority: string) {
         }
       })
       .catch((err) => {
-        logger.error({err}, 'Receive error');
+        logger.error({ err }, 'Receive error');
         throw err;
       });
   });
@@ -68,7 +68,7 @@ export function changeMessageVisibilityRecurring(priority: string, receiptHandle
   return setInterval(() => {
     if (getCurrentJobId() === jobId) {
       changeMessageVisibility(priority, receiptHandle).catch((err) => {
-        logger.warn({err}, 'Error at change msg visibility');
+        logger.warn({ err }, 'Error at change msg visibility');
       });
     }
   }, (VISIBILITY_TIMEOUT_SEC * 1000) / 3);
@@ -86,6 +86,6 @@ export async function sendMessage(jobId: string, status: JOB_UPDATE_TYPE, data =
       return await sqs.sendMessage(params).promise();
     });
   } catch (err) {
-    logger.error({err}, `Error sending SQS message: ${JSON.stringify(params)}}`);
+    logger.error({ err }, `Error sending SQS message: ${JSON.stringify(params)}}`);
   }
 }

--- a/src/aws/sqs.ts
+++ b/src/aws/sqs.ts
@@ -36,7 +36,7 @@ export async function receiveMessage(priority: string) {
         }
       })
       .catch((err) => {
-        logger.error('Receive error', err);
+        logger.error({err}, 'Receive error');
         throw err;
       });
   });
@@ -68,7 +68,7 @@ export function changeMessageVisibilityRecurring(priority: string, receiptHandle
   return setInterval(() => {
     if (getCurrentJobId() === jobId) {
       changeMessageVisibility(priority, receiptHandle).catch((err) => {
-        logger.warn('Error at change msg visibility', err);
+        logger.warn({err}, 'Error at change msg visibility');
       });
     }
   }, (VISIBILITY_TIMEOUT_SEC * 1000) / 3);
@@ -86,6 +86,6 @@ export async function sendMessage(jobId: string, status: JOB_UPDATE_TYPE, data =
       return await sqs.sendMessage(params).promise();
     });
   } catch (err) {
-    logger.error(`Error sending SQS message: ${JSON.stringify(params)}}`, err);
+    logger.error({err}, `Error sending SQS message: ${JSON.stringify(params)}}`);
   }
 }

--- a/src/bin/commands/setup.ts
+++ b/src/bin/commands/setup.ts
@@ -33,7 +33,7 @@ async function setupAction(program: any, cmd: any, platform: string, os?: string
     await setup(platform, sdkVersion);
     l.info('it\'s all set!');
   } catch (err) {
-    logger.error({err}, `Failed to setup environment for ${platform} builds`);
+    logger.error({ err }, `Failed to setup environment for ${platform} builds`);
     if (err instanceof ErrorWithCommandHelp) {
       cmd.help();
     } else if (err instanceof ErrorWithProgramHelp) {

--- a/src/bin/commands/setup.ts
+++ b/src/bin/commands/setup.ts
@@ -33,8 +33,7 @@ async function setupAction(program: any, cmd: any, platform: string, os?: string
     await setup(platform, sdkVersion);
     l.info('it\'s all set!');
   } catch (err) {
-    logger.error(`Failed to setup environment for ${platform} builds`);
-    logger.error(err.stack);
+    logger.error({err}, `Failed to setup environment for ${platform} builds`);
     if (err instanceof ErrorWithCommandHelp) {
       cmd.help();
     } else if (err instanceof ErrorWithProgramHelp) {

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -17,16 +17,16 @@ Command.prototype.asyncAction = function asyncAction(asyncFn: (...asyncFnArgs: a
   return this.action(async (...args) => {
     try {
       await checkForUpdateAsync();
-    } catch (e) {
-      logger.warn('Failed to check for turtle-cli update.');
+    } catch (err) {
+      logger.warn({err}, 'Failed to check for turtle-cli update.');
     }
     return await asyncFn(...args);
   });
 };
 
 export function run(programName: string) {
-  runAsync(programName).catch((e) => {
-    logger.error('Uncaught Error', e);
+  runAsync(programName).catch((err) => {
+    logger.error({err}, 'Uncaught Error');
     process.exit(1);
   });
 }

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -18,7 +18,7 @@ Command.prototype.asyncAction = function asyncAction(asyncFn: (...asyncFnArgs: a
     try {
       await checkForUpdateAsync();
     } catch (err) {
-      logger.warn({err}, 'Failed to check for turtle-cli update.');
+      logger.warn({ err }, 'Failed to check for turtle-cli update.');
     }
     return await asyncFn(...args);
   });
@@ -26,7 +26,7 @@ Command.prototype.asyncAction = function asyncAction(asyncFn: (...asyncFnArgs: a
 
 export function run(programName: string) {
   runAsync(programName).catch((err) => {
-    logger.error({err}, 'Uncaught Error');
+    logger.error({ err }, 'Uncaught Error');
     process.exit(1);
   });
 }

--- a/src/bin/setup/utils/toolsDetector.ts
+++ b/src/bin/setup/utils/toolsDetector.ts
@@ -26,9 +26,9 @@ export async function ensureToolsAreInstalled(tools: IToolDefinition[]) {
     } catch (err) {
       isAnyToolMissing = true;
       if (!testFn) {
-        l.error({err}, `${command} is missing in your $PATH`);
+        l.error({ err }, `${command} is missing in your $PATH`);
       }
-      l.error({err}, missingDescription);
+      l.error({ err }, missingDescription);
     }
   }
   if (isAnyToolMissing) {

--- a/src/bin/setup/utils/toolsDetector.ts
+++ b/src/bin/setup/utils/toolsDetector.ts
@@ -26,9 +26,9 @@ export async function ensureToolsAreInstalled(tools: IToolDefinition[]) {
     } catch (err) {
       isAnyToolMissing = true;
       if (!testFn) {
-        l.error(`${command} is missing in your $PATH`);
+        l.error({err}, `${command} is missing in your $PATH`);
       }
-      l.error(missingDescription);
+      l.error({err}, missingDescription);
     }
   }
   if (isAnyToolMissing) {

--- a/src/bin/utils/builder.ts
+++ b/src/bin/utils/builder.ts
@@ -72,8 +72,7 @@ export function createBuilderAction({
       const job = await sanitizeJob(rawJob);
       await builder(job);
     } catch (err) {
-      logger.error(`Failed to build standalone app: ${err.message}`);
-      logger.error(err.stack);
+      logger.error({err}, 'Failed to build standalone app');
       if (err instanceof ErrorWithCommandHelp) {
         command.help();
       } else if (err instanceof ErrorWithProgramHelp) {

--- a/src/bin/utils/builder.ts
+++ b/src/bin/utils/builder.ts
@@ -72,7 +72,7 @@ export function createBuilderAction({
       const job = await sanitizeJob(rawJob);
       await builder(job);
     } catch (err) {
-      logger.error({err}, 'Failed to build standalone app');
+      logger.error({ err }, 'Failed to build standalone app');
       if (err instanceof ErrorWithCommandHelp) {
         command.help();
       } else if (err instanceof ErrorWithProgramHelp) {

--- a/src/builders/utils/ios/keychain.ts
+++ b/src/builders/utils/ios/keychain.ts
@@ -16,7 +16,7 @@ export async function create(ctx: IContext): Promise<IKeychain> {
     l.info('done creating keychain');
     return keychainInfo;
   } catch (err) {
-    l.error({err}, 'unable to create keychain');
+    l.error({ err }, 'unable to create keychain');
     throw err;
   }
 }
@@ -32,7 +32,7 @@ export async function remove(ctx: IContext, keychainPath: string) {
     l.info('done deleting keychain');
     return keychainInfo;
   } catch (err) {
-    l.error({err}, 'unable to delete keychain');
+    l.error({ err }, 'unable to delete keychain');
     throw err;
   }
 }
@@ -57,7 +57,7 @@ export async function importCert(
     await IosKeychain.importIntoKeychain({ keychainPath, certPath, certPassword });
     l.info('done importing distribution certificate into keychain');
   } catch (err) {
-    l.error({err}, 'unable to import distribution certificate into keychain');
+    l.error({ err }, 'unable to import distribution certificate into keychain');
     throw err;
   }
 }

--- a/src/builders/utils/ios/keychain.ts
+++ b/src/builders/utils/ios/keychain.ts
@@ -16,7 +16,7 @@ export async function create(ctx: IContext): Promise<IKeychain> {
     l.info('done creating keychain');
     return keychainInfo;
   } catch (err) {
-    l.error('unable to create keychain');
+    l.error({err}, 'unable to create keychain');
     throw err;
   }
 }
@@ -32,7 +32,7 @@ export async function remove(ctx: IContext, keychainPath: string) {
     l.info('done deleting keychain');
     return keychainInfo;
   } catch (err) {
-    l.error('unable to delete keychain');
+    l.error({err}, 'unable to delete keychain');
     throw err;
   }
 }
@@ -57,7 +57,7 @@ export async function importCert(
     await IosKeychain.importIntoKeychain({ keychainPath, certPath, certPassword });
     l.info('done importing distribution certificate into keychain');
   } catch (err) {
-    l.error('unable to import distribution certificate into keychain');
+    l.error({err}, 'unable to import distribution certificate into keychain');
     throw err;
   }
 }

--- a/src/jobManager.ts
+++ b/src/jobManager.ts
@@ -47,7 +47,7 @@ export async function getJob() {
         return job;
       }
     } catch (err) {
-      logger.error({err}, 'Error at receiving messages');
+      logger.error({ err }, 'Error at receiving messages');
     }
   }
 }
@@ -160,6 +160,6 @@ async function deleteMessage(priority: string, receiptHandle: string) {
     setCurrentJobId(null);
     await sqs.deleteMessage(priority, receiptHandle);
   } catch (err) {
-    logger.error({err}, 'Error at deleting msg');
+    logger.error({ err }, 'Error at deleting msg');
   }
 }

--- a/src/jobManager.ts
+++ b/src/jobManager.ts
@@ -47,7 +47,7 @@ export async function getJob() {
         return job;
       }
     } catch (err) {
-      logger.error('Error at receiving messages', err);
+      logger.error({err}, 'Error at receiving messages');
     }
   }
 }
@@ -160,6 +160,6 @@ async function deleteMessage(priority: string, receiptHandle: string) {
     setCurrentJobId(null);
     await sqs.deleteMessage(priority, receiptHandle);
   } catch (err) {
-    logger.error('Error at deleting msg', err);
+    logger.error({err}, 'Error at deleting msg');
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import { getRedisClient, RedisClient } from 'turtle/utils/redis';
 
 const REDIS_TURTLE_VERSION_KEY = 'turtle:version';
 
-process.on('unhandledRejection', (err) => logger.error('Unhandled promise rejection:', err));
+process.on('unhandledRejection', (err) => logger.error({err}, 'Unhandled promise rejection'));
 
 function handleExit() {
   if (checkShouldExit()) {
@@ -39,19 +39,19 @@ async function main() {
     await redis.set(REDIS_TURTLE_VERSION_KEY, turtleVersion);
     logger.info(`Register Turtle version ${turtleVersion} in Redis`);
   } catch (err) {
-    logger.error('Failed to register Turtle version in Redis', err);
+    logger.error({err}, 'Failed to register Turtle version in Redis');
   }
 
   while (true) {
     try {
       await doJob();
     } catch (err) {
-      logger.error('Failed to do a job', err);
+      logger.error({err}, 'Failed to do a job');
     }
   }
 }
 
 main()
   .then(() => logger.error('This should never happen...'))
-  .catch((err) => logger.error('Something went terribly wrong :(', err))
+  .catch((err) => logger.error({err}, 'Something went terribly wrong'))
   .then(() => process.exit(1));

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,7 @@ import { getRedisClient, RedisClient } from 'turtle/utils/redis';
 
 const REDIS_TURTLE_VERSION_KEY = 'turtle:version';
 
-process.on('unhandledRejection', (err) => logger.error({err}, 'Unhandled promise rejection'));
+process.on('unhandledRejection', (err) => logger.error({ err }, 'Unhandled promise rejection'));
 
 function handleExit() {
   if (checkShouldExit()) {
@@ -39,19 +39,19 @@ async function main() {
     await redis.set(REDIS_TURTLE_VERSION_KEY, turtleVersion);
     logger.info(`Register Turtle version ${turtleVersion} in Redis`);
   } catch (err) {
-    logger.error({err}, 'Failed to register Turtle version in Redis');
+    logger.error({ err }, 'Failed to register Turtle version in Redis');
   }
 
   while (true) {
     try {
       await doJob();
     } catch (err) {
-      logger.error({err}, 'Failed to do a job');
+      logger.error({ err }, 'Failed to do a job');
     }
   }
 }
 
 main()
   .then(() => logger.error('This should never happen...'))
-  .catch((err) => logger.error({err}, 'Something went terribly wrong'))
+  .catch((err) => logger.error({ err }, 'Something went terribly wrong'))
   .then(() => process.exit(1));

--- a/src/utils/priorities.ts
+++ b/src/utils/priorities.ts
@@ -60,24 +60,23 @@ export async function getPriorities() {
       logger.debug(`Using configuration at index ${configurationsIndex} pulled from redis`);
       const { error, value: configValue } = configSchema.validate(configurations[configurationsIndex]);
       if (error) {
-        logger.warn(error);
+        logger.warn({err: error});
         throw new Error('Received configuration is not valid');
       }
       return configValue;
     } catch (err) {
-      logger.warn(err);
+      logger.warn({err});
       const defaultConfig = JSON.parse(await redis.get(createDefaultConfigurationKey()));
       const { error, value: defaultConfigValue } = configSchema.validate(defaultConfig);
       if (error) {
-        logger.warn(error);
+        logger.warn({err: error});
         throw new Error('Received default configuration is not valid');
       }
       logger.warn('Using default configuration pulled from redis');
       return defaultConfigValue;
     }
   } catch (err) {
-    logger.warn(err);
-    logger.warn('Using configuration chosen locally');
+    logger.warn({err}, 'Using configuration chosen locally');
     if (Math.random() < 0.7) {
       return HIGH_CONFIGURATION;
     } else {

--- a/src/utils/priorities.ts
+++ b/src/utils/priorities.ts
@@ -60,23 +60,23 @@ export async function getPriorities() {
       logger.debug(`Using configuration at index ${configurationsIndex} pulled from redis`);
       const { error, value: configValue } = configSchema.validate(configurations[configurationsIndex]);
       if (error) {
-        logger.warn({err: error});
+        logger.warn({ err: error });
         throw new Error('Received configuration is not valid');
       }
       return configValue;
     } catch (err) {
-      logger.warn({err});
+      logger.warn({ err });
       const defaultConfig = JSON.parse(await redis.get(createDefaultConfigurationKey()));
       const { error, value: defaultConfigValue } = configSchema.validate(defaultConfig);
       if (error) {
-        logger.warn({err: error});
+        logger.warn({ err: error });
         throw new Error('Received default configuration is not valid');
       }
       logger.warn('Using default configuration pulled from redis');
       return defaultConfigValue;
     }
   } catch (err) {
-    logger.warn({err}, 'Using configuration chosen locally');
+    logger.warn({ err }, 'Using configuration chosen locally');
     if (Math.random() < 0.7) {
       return HIGH_CONFIGURATION;
     } else {

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -52,7 +52,7 @@ export async function getRedisClient(type = RedisClient.Default) {
     try {
       redisClients[type] = await connect(MILLIS_CONNECTION_TIMEOUT, type);
     } catch (err) {
-      logger.error({err});
+      logger.error({ err });
     }
   }
   return redisClients[type];
@@ -66,7 +66,7 @@ export async function checkIfCancelled(jobId: string) {
     if (config.deploymentEnv === 'development') {
       logger.warn('Did you turn on redis server? Run `yarn start-docker` in server/www');
     }
-    logger.error({err});
+    logger.error({ err });
     return false;
   }
 }

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -52,7 +52,7 @@ export async function getRedisClient(type = RedisClient.Default) {
     try {
       redisClients[type] = await connect(MILLIS_CONNECTION_TIMEOUT, type);
     } catch (err) {
-      logger.error(err);
+      logger.error({err});
     }
   }
   return redisClients[type];
@@ -66,7 +66,7 @@ export async function checkIfCancelled(jobId: string) {
     if (config.deploymentEnv === 'development') {
       logger.warn('Did you turn on redis server? Run `yarn start-docker` in server/www');
     }
-    logger.error(err);
+    logger.error({err});
     return false;
   }
 }


### PR DESCRIPTION
# Why

This makes log messages slightly easier to read in our monitoring dashboards, and also makes it slightly easier to search for or alert on particular errors.

# How

[The bunyan log method api](https://github.com/trentm/node-bunyan#log-method-api) supports a few different ways of logging messages at a certain level. I preferred the last way - passing an object with an `err` field as the first argument - since it was more explicit, and makes it more obvious how to add more fields.

I would like there to be many more fields, for example it would be very good if all messages related to a particular build were tagged with the build's id, the app's slug, and the initiating user.  But that would be a broader change I won't prioritize right now.

# Test Plan

I've checked the behavior of these arguments on the cli. For example:

```
logger.error(
  {err: new Error('wohoooo'), arbitrary: "labels"},
  `"${subCommand}" is not an ${programName} command. See "${programName} --help" for the full list of commands.`,
);
```
```
$ bin/turtle.js foo
Apr 2 13:39:20 turtle[14110] ERROR: "foo" is not an turtle command. See "turtle --help" for the full list of commands.
  err: Error: wohoooo
      at runAsync (./src/bin/index.ts:50:26)
      at Object.run (./src/bin/index.ts:28:3)
      at Object.<anonymous> (./bin/turtle.js:6:31)
      at Module._compile (module.js:653:30)
      at Object.Module._extensions..js (module.js:664:10)
      at Module.load (module.js:566:32)
      at tryModuleLoad (module.js:506:12)
      at Function.Module._load (module.js:498:3)
      at Function.Module.runMain (module.js:694:10)
      at startup (bootstrap_node.js:204:16)
      at bootstrap_node.js:625:3
  platform: "ios"
  environment: null
  arbitrary: "labels"
```