### PR TITLE
record jobID and experience name in gcloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 node_modules
 yarn-error.log
+google-cloud-credentials.json
 
 /build/
 /workingdir/*

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,1 @@
+fixtures/

--- a/src/logger/gcloudStream.ts
+++ b/src/logger/gcloudStream.ts
@@ -1,0 +1,58 @@
+import EventEmitter from 'events';
+
+import { IJob } from 'turtle/job';
+
+// type error when using import
+// https://github.com/googleapis/nodejs-logging-bunyan/issues/241
+// tslint:disable-next-line:no-var-requires
+const { LoggingBunyan } = require('@google-cloud/logging-bunyan');
+
+export interface IGCloudConfig {
+  name: string;
+  resource: {
+    type: string;
+    labels: {
+      node_id: string;
+      location: string;
+      namespace: string;
+    };
+  };
+}
+
+interface IGCloudExtraFields {
+  jobID: string;
+  experienceName: string;
+}
+
+export default class GCloudStream extends EventEmitter {
+  private logsStream: any;
+  private extraFields: IGCloudExtraFields | null;
+
+   constructor(gcloudConfig: IGCloudConfig) {
+    super();
+
+    const { name, resource } = gcloudConfig;
+    this.logsStream = new LoggingBunyan({ name, resource });
+    this.extraFields = null;
+  }
+
+  public init(job: IJob) {
+    this.extraFields = {
+      jobID: job.id,
+      experienceName: job.experienceName,
+    };
+  }
+
+  public cleanup() {
+    this.extraFields = null;
+  }
+
+  public write(rec: any) {
+    const { msg: message, ...other } = rec;
+    this.logsStream.write({
+      message,
+      ...other,
+      data: this.extraFields || {},
+    });
+  }
+}


### PR DESCRIPTION
# Why

To make it easier to find logs in GCloud Console.

# How

Basically, I copy-pasted `HackyLogglyStream` that we previously used in the project - https://github.com/expo/turtle/blob/de4837f36105c03be9afb4028241cff7459da974/src/logger/hackyLogglyStream.ts

# Test Plan

Tested locally.
<img width="487" alt="Screenshot 2019-04-15 at 15 09 37" src="https://user-images.githubusercontent.com/5256730/56135267-a3d3b200-5f90-11e9-9c96-505380b9f10c.png">

