### PR TITLE
Add support for Android tarballs without universe-package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for custom builds on android
+- Support for Android tarballs without `universe-package.json`
 
 ## [0.6.1] - 2019-04-23
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,11 +103,15 @@ ADD . /app
 
 RUN for SDK_VERSION in `ls /app/workingdir/android/`; do \
       cd /app/workingdir/android/$SDK_VERSION && \
+      if [ -f universe-package.json ]; then \
       mv package.json exponent-package.json && \
       mv universe-package.json package.json && \
       yarn install && \
       mv package.json universe-package.json && \
-      mv exponent-package.json package.json \
+      mv exponent-package.json package.json; \
+      else \
+      yarn install; \
+      fi \
     ; done
 
 WORKDIR /app


### PR DESCRIPTION
# Why

If possible, we'd like to get rid of a special kind of `package.json` only for Turtle environment.

# How

If a tarball doesn't contain `universe-package.json`, install dependencies from the default `package.json` provided.

# Test Plan

Created a simple 3 directories tree and ensured that this command should do what it's supposed to do. The following script:

```sh
for SDK_VERSION in `ls workingdir`; do \
      cd ~/tmp/workingdir/$SDK_VERSION; \
      if [ -f universe-package.json ]; then \
      echo "universe" && echo $SDK_VERSION; \
      else \
      echo "expo" && echo $SDK_VERSION; \
      fi \
    ; done
```

printed

```
expo
sdk30
universe
sdk31
expo
sdk32
```

for

```
workingdir
├── sdk30
├── sdk31
│   └── universe-package.json
└── sdk32
```
