### PR TITLE
[android] Update shell tarball for SDK32 with AppAuth fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Turtle CLI logo to the project (created by [@zularizal](https://github.com/zularizal))!
+### Changed
+- Updated Android shell app for SDK 32 to fix AppAuth issue (https://github.com/expo/expo/pull/4115).
 
 ## [0.7.2] - 2019-05-09
 ### Added

--- a/shellTarballs/android/sdk32
+++ b/shellTarballs/android/sdk32
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-0cab68670fc50ce1dc16b7d86ca7976870062c39.tar.gz
+s3://exp-artifacts/android-shell-builder-c4ba6f73ab341afa378732f863e261a10fc71356.tar.gz


### PR DESCRIPTION
We want to backport [fix](https://github.com/expo/expo/pull/4115) to SDK32.