### PR TITLE
[turtle-cli] fix generating android keystore

### DIFF
--- a/src/bin/commands/build/android.ts
+++ b/src/bin/commands/build/android.ts
@@ -38,6 +38,7 @@ const buildJobObject = (appJSON: any, { releaseChannel, username, projectDir, pu
   config: {
     ..._.get(appJSON, 'expo.android.config', {}),
     releaseChannel,
+    androidPackage: _.get(appJSON, 'expo.android.package'),
     publicUrl,
   },
   id: uuid.v4(),

--- a/src/builders/utils/android/credentials.ts
+++ b/src/builders/utils/android/credentials.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import fs from 'fs-extra';
+import get from 'lodash/get';
 import uuidv4 from 'uuid/v4';
 import { Credentials } from 'xdl';
 
@@ -19,7 +20,14 @@ async function getOrCreateCredentials(jobData: IJob): Promise<IAndroidCredential
     credentials.keystorePassword = uuidv4().replace(/-/g, '');
     credentials.keyPassword = uuidv4().replace(/-/g, '');
     credentials.keystoreAlias = Buffer.from(jobData.experienceName).toString('base64');
-    const androidPackage = jobData.manifest.android.package;
+    const androidPackage =
+      get(jobData, 'manifest.android.package')
+      || get(jobData, 'config.androidPackage');
+    if (!androidPackage) {
+      throw new Error(
+        'Android package name is not set in the app manifest (please update app.json if you\'re using turtle-cli).',
+      );
+    }
 
     await Credentials.Android.createKeystore(
       {

--- a/src/job.ts
+++ b/src/job.ts
@@ -12,6 +12,8 @@ export interface IJob {
     // ios
     buildType?: IOS.BUILD_TYPES;
     bundleIdentifier?: string;
+    // android
+    androidPackage?: string;
   };
   credentials: {
     // android


### PR DESCRIPTION
# Why

Fixes #64

When a user uses turtle-cli, and he wants to build for Android, and he doesn't provide the keystore for his app (by setting proper options and env variables) we fail to create one for him.

# How

When we build for Android and we discover that a keystore doesn't exist we try to read Android package name from the app manifest. Unfortunately, the app manifest is not accessible for Turtle CLI builds, so I passed in another variable to job config and used that in Android credentials utils.

# Test Plan

Tested locally.