### PR TITLE
added code to publish ipa to itunes

### DIFF
--- a/src/builders/ios/index.ts
+++ b/src/builders/ios/index.ts
@@ -40,9 +40,9 @@ export default async function iosBuilder(job: IJob): Promise<IJobResult> {
 
     // Upload to app store
     if (job.config.upload) {
-      const { options } = job.config;
+      const { options, bundleIdentifier } = job.config;
       if (options) {
-        await uploadBuildToTestFlight(ctx, options);
+        await uploadBuildToTestFlight(ctx, options, bundleIdentifier);
       }
     }
 

--- a/src/builders/ios/index.ts
+++ b/src/builders/ios/index.ts
@@ -6,7 +6,7 @@ import { createBuilderContext, IContext } from 'turtle/builders/ios/context';
 import buildSimulator from 'turtle/builders/ios/simulator';
 import { logErrorOnce } from 'turtle/builders/utils/common';
 import prepareAdHocBuildCredentials from 'turtle/builders/utils/ios/adhocBuild';
-import { uploadBuildToS3 } from 'turtle/builders/utils/uploader';
+import { uploadBuildToS3, uploadBuildToTestFlight } from 'turtle/builders/utils/uploader';
 import { ensureCanBuildSdkVersion } from 'turtle/builders/utils/version';
 import config from 'turtle/config';
 import { IOS } from 'turtle/constants/index';
@@ -36,6 +36,14 @@ export default async function iosBuilder(job: IJob): Promise<IJobResult> {
       await buildSimulator(ctx, job);
     } else {
       throw new Error(`Unsupported iOS build type: ${buildType}`);
+    }
+
+    // Upload to app store
+    if (job.config.upload) {
+      const { options } = job.config;
+      if (options) {
+        await uploadBuildToTestFlight(ctx, options);
+      }
     }
 
     const artifactUrl = await uploadBuildToS3(ctx);

--- a/src/builders/utils/uploader.ts
+++ b/src/builders/utils/uploader.ts
@@ -1,11 +1,10 @@
 import * as fs from 'fs-extra';
+import { ExponentTools } from 'xdl';
 
 import { uploadFile } from 'turtle/aws/s3';
 import { IContext } from 'turtle/builders/ios/context';
 import config from 'turtle/config';
 import logger from 'turtle/logger';
-
-import { ExponentTools } from 'xdl';
 
 interface IUploadCtx {
   fakeUploadBuildPath?: string;

--- a/src/builders/utils/uploader.ts
+++ b/src/builders/utils/uploader.ts
@@ -40,19 +40,19 @@ export async function uploadBuildToS3(ctx: IUploadCtx) {
 
 export async function uploadBuildToTestFlight(ctx: IContext, options: IJobOptions, bundleIdentifier: string) {
   const fastlaneEnvVars = {
-    FASTLANE_USER: options.username,
+    FASTLANE_USER: options.appleId,
     FASTLANE_SKIP_UPDATE_CHECK: 1,
     FASTLANE_DISABLE_COLORS: 1,
     CI: 1,
     LC_ALL: 'en_US.UTF-8',
-    FASTLANE_PASSWORD: options.password,
-    FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: options.appPassword,
+    FASTLANE_PASSWORD: options.applePassword,
+    FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: options.appSpecificPassword,
   };
 
   await runFastlane([
     'produce',
     '--username',
-    options.username,
+    options.appleId,
     '--app_identifier', // bundle id
     bundleIdentifier,
     '--app_name',
@@ -67,7 +67,7 @@ export async function uploadBuildToTestFlight(ctx: IContext, options: IJobOption
     'pilot',
     'upload',
     '--username',
-    options.username,
+    options.appleId,
     '--ipa',
     ctx.uploadPath,
     '--apple_id', // The unique App ID provided by App Store Connect

--- a/src/builders/utils/uploader.ts
+++ b/src/builders/utils/uploader.ts
@@ -71,11 +71,11 @@ export async function uploadBuildToTestFlight(ctx: IContext, options: IJobOption
       ...fastlaneEnvVars,
     },
     pipeToLogger: true,
-    dontShowStdout: false
-    { buildPhase: 'Creating App on AppStoreConnect' };
-  })
+    dontShowStdout: false,
+    loggerFields: { buildPhase: 'Creating App on AppStoreConnect' },
+  });
 
-const uploadArgs = [
+  const uploadArgs = [
     'pilot',
     'upload',
     '--username',
@@ -88,13 +88,13 @@ const uploadArgs = [
     '--skip_waiting_for_build_processing',
   ];
 
-await ExponentTools.spawnAsyncThrowError('fastlane', uploadArgs, {
+  await ExponentTools.spawnAsyncThrowError('fastlane', uploadArgs, {
     env: {
       ...process.env,
       ...fastlaneEnvVars,
     },
     pipeToLogger: true,
-    dontShowStdout: false
-    { buildPhase: 'Uploading IPA to Testflight' },
+    dontShowStdout: false,
+    loggerFields: { buildPhase: 'Uploading IPA to Testflight' },
   });
 }

--- a/src/builders/utils/uploader.ts
+++ b/src/builders/utils/uploader.ts
@@ -13,8 +13,11 @@ interface IUploadCtx {
 }
 
 interface IJobOptions {
-  username: string;
-  password: string;
+  appleId: string;
+  applePassword: string;
+  appSpecificPassword: string;
+  appName: string;
+  companyName: string;
 }
 
 export async function uploadBuildToS3(ctx: IUploadCtx) {

--- a/src/builders/utils/uploader.ts
+++ b/src/builders/utils/uploader.ts
@@ -40,7 +40,7 @@ export async function uploadBuildToS3(ctx: IUploadCtx) {
   }
 }
 
-export async function uploadBuildToTestFlight(ctx: IContext, options: IJobOptions, bundleIdentifier: ?string) {
+export async function uploadBuildToTestFlight(ctx: IContext, options: IJobOptions, bundleIdentifier?: string) {
   const fastlaneEnvVars = {
     FASTLANE_USER: options.appleId,
     FASTLANE_SKIP_UPDATE_CHECK: 1,

--- a/src/builders/utils/uploader.ts
+++ b/src/builders/utils/uploader.ts
@@ -59,7 +59,7 @@ export async function uploadBuildToTestFlight(ctx: IContext, options: IJobOption
     bundleIdentifier,
     '--app_name',
     options.appName,
-    '--app_version'
+    '--app_version',
     '1.0',
     '--company_name',
     options.companyName,

--- a/src/job.ts
+++ b/src/job.ts
@@ -14,9 +14,11 @@ export interface IJob {
     bundleIdentifier?: string;
     upload?: boolean;
     options?: {
-      // apple credentials
-      username: string;
-      password: string;
+      appleId: string;
+      applePassword: string;
+      appSpecificPassword: string;
+      appName: string;
+      companyName: string;
     };
     // android
     androidPackage?: string;

--- a/src/job.ts
+++ b/src/job.ts
@@ -12,6 +12,12 @@ export interface IJob {
     // ios
     buildType?: IOS.BUILD_TYPES;
     bundleIdentifier?: string;
+    upload?: boolean;
+    options?: {
+      // apple credentials
+      username: string;
+      password: string;
+    };
     // android
     androidPackage?: string;
   };


### PR DESCRIPTION
# Why

Allows a snack ios app to also be pushed to itunes Connect using fastlane. Adds job config options to make this possible. See: expo/universe#3546

# How

Added a function that is sometimes called after building the ipa, to upload that ipa to iTunes Connect using fastlane.

# Test Plan
