### PR TITLE
[turtle] use provisioiningProfileId if specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Adhoc Builds: use provisioningProfileId if specified.
 - Registering supported SDK versions in Redis.
 
 ## [0.8.6] - 2019-06-25

--- a/src/builders/utils/ios/adhocBuild.ts
+++ b/src/builders/utils/ios/adhocBuild.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import spawnAsync from '@expo/spawn-async';
 import { IosCodeSigning } from '@expo/xdl';
 import fs from 'fs-extra';
-import isEmpty from 'lodash/isEmpty';
 
 import * as sqs from 'turtle/aws/sqs';
 import BuildError, { BuildErrorReason } from 'turtle/builders/BuildError';
@@ -27,12 +26,12 @@ async function prepareAdHocBuildCredentials(job: IJob) {
     teamId,
     appleSession,
     udids,
-    provisioningProfileId
+    provisioningProfileId,
   } = job.credentials;
 
   const certSerialNumber = IosCodeSigning.findP12CertSerialNumber(certP12, certPassword);
   const args = [
-    ...(provisioningProfileId ? ["--profile-id", provisioningProfileId] : []),
+    ...(provisioningProfileId ? ['--profile-id', provisioningProfileId] : []),
     teamId,
     udids!.join(','),
     bundleIdentifier,

--- a/src/job.ts
+++ b/src/job.ts
@@ -26,6 +26,7 @@ export interface IJob {
     certP12?: string;
     certPassword?: string;
     provisioningProfile?: string;
+    provisioningProfileId?: string;
     teamId?: string;
     appleSession?: string;
     udids?: string[];


### PR DESCRIPTION
# Why
- Allow the clients to specify a profile id for turtle to use
- the new `manage_adhoc_profile.rb` script should always return either a valid profile or error. Instead of detecting for empty credentials (which should no longer be the case), we check if the profile has been updated. If it has, we continue with the logic to save it on our servers, else we return.

# related prs
https://github.com/expo/expo-cli/pull/700
https://github.com/expo/turtle/pull/88
https://github.com/expo/universe/pull/3573

# todo

- [ ] bump traveling fastlane
