### PR TITLE
turtle-cli fixes for sdk 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated Android shell app for SDK33 to remove `expo-face-detector` and `expo-payments-stripe` from standalone builds.
+- Updated Android shell app for SDK33 to get rid of `node_modules` for `tools-public`.
+- From now on, `turtle-cli` installs dependencies for `tools-public` in shell apps for SDK versions < 33.
+### Fixed
+- Android builds with turtle-cli by installing all unmodules if `dependencies` is empty.
 
 ## [0.8.1] - 2019-06-10
 ### Changed

--- a/shellTarballs/android/sdk33
+++ b/shellTarballs/android/sdk33
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-5d51dcbeaabfcc29d6aa9f268719d10ca7cfe6b0.tar.gz
+s3://exp-artifacts/android-shell-builder-e244e865ed8cb8e20d29ea00b6373845d1c61068.tar.gz

--- a/src/bin/setup/android/index.ts
+++ b/src/bin/setup/android/index.ts
@@ -67,7 +67,7 @@ function formatShellAppTarballUriPath(sdkMajorVersion: string) {
   return path.join(config.directories.shellTarballsDir, PLATFORMS.ANDROID, `sdk${sdkMajorVersion}`);
 }
 
-async function _shellAppPostDownloadAction(workingdir: string) {
+async function _shellAppPostDownloadAction(sdkVersion: string, workingdir: string) {
   const inWorkingdir = (filename: string) => path.join(workingdir, filename);
 
   if (await fs.pathExists(inWorkingdir('universe-package.json'))) {
@@ -82,9 +82,11 @@ async function _shellAppPostDownloadAction(workingdir: string) {
     await _installNodeModules(workingdir);
   }
 
-  // TODO: remove following lines after upgrading android shell app
-  const toolsPublicDir = path.join(workingdir, 'tools-public');
-  await _installNodeModules(toolsPublicDir);
+  // TODO: remove this after making sure that we don't need node_modules in tools-public for older sdks
+  if (ExponentTools.parseSdkMajorVersion(sdkVersion) < 33) {
+    const toolsPublicDir = path.join(workingdir, 'tools-public');
+    await _installNodeModules(toolsPublicDir);
+  }
 }
 
 async function _installNodeModules(cwd: string) {

--- a/src/bin/setup/utils/common.ts
+++ b/src/bin/setup/utils/common.ts
@@ -17,7 +17,7 @@ interface IShellAppFormaters {
   formatShellAppTarballUriPath: (sdkMajorVersion: string) => string;
 }
 
-type PostDownloadAction = (workingdir: string) => void;
+type PostDownloadAction = (sdkVersion: string, workingdir: string) => void;
 
 export async function checkSystem(requiredTools: IToolDefinition[]) {
   await ensureToolsAreInstalled(requiredTools);
@@ -35,7 +35,7 @@ export async function ensureShellAppIsPresent(
   l.info(`shell app for SDK ${sdkVersion} doesn't exist, downloading...`);
   await _downloadShellApp(sdkVersion, workingdir, formatters);
   if (postDownloadAction) {
-    await postDownloadAction(workingdir);
+    await postDownloadAction(sdkVersion, workingdir);
   }
 }
 

--- a/src/builders/android.ts
+++ b/src/builders/android.ts
@@ -75,7 +75,7 @@ async function runShellAppBuilder(
 
   logger.info({ buildPhase: 'resolve native modules' }, 'Resolving universal modules dependencies');
   const enabledModules = semver.satisfies(sdkVersion, '>= 33.0.0')
-    ? await resolveNativeModules(workingDir, manifest.dependencies)
+    ? await resolveNativeModules(workingDir, manifest && manifest.dependencies)
     : null;
 
   try {


### PR DESCRIPTION
# Why

#85, #86

# How

- I changed the Android shell app for SDK33 to a one without node_modules in tools-public.
- From now on, `turtle-cli` will install dependencies for `tools-public` in shell apps only for SDK versions < 33.
- I fixed installing native modules when `manifest` is undefined.
