### PR TITLE
fetch manifest in turtle-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- fetch manifest in turtle-cli
 
 ## [0.8.2] - 2019-06-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- fetch manifest in turtle-cli
+- `turtle-cli` is now fetching the app manifest before running the build.
 
 ## [0.8.2] - 2019-06-11
 ### Changed

--- a/src/bin/commands/build/android.ts
+++ b/src/bin/commands/build/android.ts
@@ -1,6 +1,5 @@
 import fs from 'fs-extra';
 import _ from 'lodash';
-import uuid from 'uuid';
 
 import { ErrorWithCommandHelp } from 'turtle/bin/commands/ErrorWithCommandHelp';
 import { createBuilderAction } from 'turtle/bin/utils/builder';
@@ -33,33 +32,12 @@ export default (program: any, setCommonCommandOptions: any) => {
         program,
         command,
         prepareCredentials,
-        buildJobObject,
         builder,
         platform: PLATFORMS.ANDROID,
         os: ['darwin', 'linux'],
       }),
     );
 };
-
-const buildJobObject = (
-  appJSON: any,
-  { releaseChannel, username, projectDir, publicUrl, buildType }: any,
-  credentials: any,
-) => ({
-  config: {
-    ..._.get(appJSON, 'expo.android.config', {}),
-    releaseChannel,
-    androidPackage: _.get(appJSON, 'expo.android.package'),
-    publicUrl,
-    buildType,
-  },
-  id: uuid.v4(),
-  platform: PLATFORMS.ANDROID,
-  sdkVersion: _.get(appJSON, 'expo.sdkVersion'),
-  projectDir,
-  experienceName: `@${username}/${_.get(appJSON, 'expo.slug')}`,
-  ...(credentials && { credentials }),
-});
 
 const prepareCredentials = async (cmd: any) => {
   const { keystorePath, keystoreAlias } = cmd;

--- a/src/bin/commands/build/ios.ts
+++ b/src/bin/commands/build/ios.ts
@@ -1,6 +1,5 @@
 import fs from 'fs-extra';
 import _ from 'lodash';
-import uuid from 'uuid';
 
 import { ErrorWithCommandHelp } from 'turtle/bin/commands/ErrorWithCommandHelp';
 import { createBuilderAction } from 'turtle/bin/utils/builder';
@@ -32,28 +31,12 @@ export default (program: any, setCommonCommandOptions: any) => {
         program,
         command,
         prepareCredentials,
-        buildJobObject,
         builder,
         platform: PLATFORMS.IOS,
         os: 'darwin',
       }),
     );
 };
-
-const buildJobObject = (appJSON: any, { releaseChannel, buildType, username, publicUrl }: any, credentials: any) => ({
-  config: {
-    ..._.get(appJSON, 'expo.ios.config', {}),
-    buildType,
-    releaseChannel,
-    bundleIdentifier: _.get(appJSON, 'expo.ios.bundleIdentifier'),
-    publicUrl,
-  },
-  id: uuid.v4(),
-  platform: PLATFORMS.IOS,
-  sdkVersion: _.get(appJSON, 'expo.sdkVersion'),
-  experienceName: `@${username}/${_.get(appJSON, 'expo.slug')}`,
-  ...(credentials && { credentials }),
-});
 
 const prepareCredentials = async (cmd: any) => {
   if (cmd.type !== IOS_BUILD_TYPES.ARCHIVE) {

--- a/src/builders/android.ts
+++ b/src/builders/android.ts
@@ -75,12 +75,12 @@ async function runShellAppBuilder(
 
   logger.info({ buildPhase: 'resolve native modules' }, 'Resolving universal modules dependencies');
   const enabledModules = semver.satisfies(sdkVersion, '>= 33.0.0')
-    ? await resolveNativeModules(workingDir, manifest && manifest.dependencies)
+    ? await resolveNativeModules(workingDir, _.get(manifest, 'dependencies'))
     : null;
 
   try {
     await AndroidShellApp.createAndroidShellAppAsync({
-      url: commonUtils.getExperienceUrl(jobData),
+      url: commonUtils.getExperienceUrl(jobData.experienceName, jobData.config.publicUrl),
       sdkVersion,
       keystore: tempKeystorePath,
       manifest,

--- a/src/builders/utils/common.ts
+++ b/src/builders/utils/common.ts
@@ -1,13 +1,9 @@
 import * as url from 'url';
 
 import config from 'turtle/config';
-import { IJob } from 'turtle/job';
 import logger from 'turtle/logger';
 
-export function getExperienceUrl(job: IJob) {
-  const { experienceName, config: jobConfig } = job;
-  const { publicUrl } = jobConfig;
-
+export function getExperienceUrl(experienceName: string, publicUrl?: string) {
   // publicUrl is passed in if user wants to build an externally hosted app
   if (publicUrl) {
     return publicUrl;

--- a/src/builders/utils/ios/shellAppBuilder.ts
+++ b/src/builders/utils/ios/shellAppBuilder.ts
@@ -43,7 +43,7 @@ export default async function runShellAppBuilder(ctx: IContext, job: IJob): Prom
     });
   } else {
     Object.assign(shellAppParams, {
-      url: commonUtils.getExperienceUrl(job),
+      url: commonUtils.getExperienceUrl(job.experienceName, job.config.publicUrl),
       releaseChannel,
       sdkVersion,
     });


### PR DESCRIPTION
# Why

For turtle-cli builds manifest was fetched by xdl, so when unimodules were resolved it was not available

