### PR TITLE
[turtle-cli] fix updating shell apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Upgrading the shell app for a given SDK version when the previous version is already downloaded (bug in `turtle-cli`).
 
 ## [0.8.4] - 2019-06-13
 ### Changed

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepare": "rimraf ./build && yarn build",
     "build": "ttsc",
     "build:production": "./scripts/build.sh",
+    "watch": "ttsc --watch",
     "secrets:init-private": "./scripts/initPrivateSecrets.sh",
     "set-workingdir:remote": "./scripts/setWorkingdirMode.sh remote",
     "set-workingdir:local": "./scripts/setWorkingdirMode.sh local",

--- a/src/bin/setup/android/ndk.ts
+++ b/src/bin/setup/android/ndk.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import decompress from 'decompress';
 import fs from 'fs-extra';
 
-import { formatArtifactDownloadPath } from 'turtle/bin/setup/utils/common';
+import * as utils from 'turtle/bin/setup/utils/common';
 import download from 'turtle/bin/setup/utils/downloader';
 import config from 'turtle/config';
 import logger from 'turtle/logger';
@@ -16,9 +16,10 @@ const l = logger.child(LOGGER_FIELDS);
 
 export default async function ensureAndroidNDKIsPresent() {
   const androidNdkDir = path.join(config.directories.androidDependenciesDir, 'ndk');
+  await utils.removeDirectoryUnlessReady(androidNdkDir);
   if (!(await fs.pathExists(androidNdkDir))) {
     await fs.ensureDir(androidNdkDir);
-    const androidNdkDownloadPath = formatArtifactDownloadPath(ANDROID_NDK_URL);
+    const androidNdkDownloadPath = utils.formatArtifactDownloadPath(ANDROID_NDK_URL);
 
     try {
       l.info('Downloading Android NDK');
@@ -26,6 +27,7 @@ export default async function ensureAndroidNDKIsPresent() {
       await download(ANDROID_NDK_URL, androidNdkDownloadPath);
       l.info('Decompressing Android NDK');
       await decompress(androidNdkDownloadPath, androidNdkDir, { strip: 1 });
+      await utils.markDirectoryAsReady(androidNdkDir);
       l.info('Android NDK installed successfully');
     } catch (err) {
       await fs.remove(androidNdkDir);

--- a/src/bin/setup/android/sdk.ts
+++ b/src/bin/setup/android/sdk.ts
@@ -5,7 +5,7 @@ import { ExponentTools } from '@expo/xdl';
 import decompress from 'decompress';
 import fs from 'fs-extra';
 
-import { formatArtifactDownloadPath } from 'turtle/bin/setup/utils/common';
+import * as utils from 'turtle/bin/setup/utils/common';
 import download from 'turtle/bin/setup/utils/downloader';
 import config from 'turtle/config';
 import logger from 'turtle/logger';
@@ -17,9 +17,10 @@ const l = logger.child(LOGGER_FIELDS);
 
 export default async function ensureAndroidSDKIsPresent() {
   const androidSdkDir = path.join(config.directories.androidDependenciesDir, 'sdk');
+  await utils.removeDirectoryUnlessReady(androidSdkDir);
   if (!(await fs.pathExists(androidSdkDir))) {
     await fs.ensureDir(androidSdkDir);
-    const androidSdkDownloadPath = formatArtifactDownloadPath(ANDROID_SDK_URL);
+    const androidSdkDownloadPath = utils.formatArtifactDownloadPath(ANDROID_SDK_URL);
 
     try {
       l.info('Downloading Android SDK');
@@ -31,6 +32,7 @@ export default async function ensureAndroidSDKIsPresent() {
       await fs.remove(androidSdkDownloadPath);
       l.info('Configuring Android SDK, this may take a while');
       await _configureSdk(androidSdkDir);
+      await utils.markDirectoryAsReady(androidSdkDir);
       l.info('Android SDK installed and configured successfully');
     } catch (err) {
       await fs.remove(androidSdkDir);


### PR DESCRIPTION
# Why

Upgrading shell apps is currently broken for users who use `turtle-cli`. During `setup:` phase we only check whether the shell app exists, we don't check its version.

# How

After successfully setting up a shell app for a given platform and SDK version, I added creating a file in the shell app directory with the version of that shell app. Before each run of `turtle-cli` I check if the version is up-to-date and if it's not we remove the cached version from `~/.turtle` directory and download a new version from S3.


# Test Plan

Tested locally.