### PR TITLE
fix android debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.11] - 2019-07-16
+### Fixed
+- Android debug builds.
+
 ## [0.8.10] - 2019-07-16
 ### Fixed
 - iOS simulator builds.

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "dependencies": {
     "@expo/spawn-async": "^1.4.2",
-    "@expo/xdl": "56.0.1-rc.1",
+    "@expo/xdl": "56.1.2-rc.1",
     "@google-cloud/logging-bunyan": "^0.9.5",
     "async-retry": "^1.2.1",
     "aws-sdk": "^2.226.1",

--- a/src/builders/utils/android/credentials.ts
+++ b/src/builders/utils/android/credentials.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { Credentials } from '@expo/xdl';
+import { AndroidCredentials } from '@expo/xdl';
 import fs from 'fs-extra';
 import get from 'lodash/get';
 import uuidv4 from 'uuid/v4';
@@ -29,7 +29,7 @@ async function getOrCreateCredentials(jobData: IJob): Promise<IAndroidCredential
       );
     }
 
-    await Credentials.Android.createKeystore(
+    await AndroidCredentials.createKeystore(
       {
         keystorePath: keystoreFilename,
         keystorePassword: credentials.keystorePassword,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,31 +1164,31 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/config@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/config/-/config-2.1.0.tgz#8d73e014283f35d1a79e337179117767e3e3a194"
-  integrity sha512-xAbUKdTquT7hd+OAwAPRiD/waiP8N4rYgw6ApjPOzerhO3X8RFaHZlHIDEBL9Odj7ymAz/lKT44gc1gEjkHDOQ==
+"@expo/config@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-2.1.2.tgz#f745a85e7c9c5f76c5da153e660f37a4db764d58"
+  integrity sha512-aNvkGFFsd5FYXC1t7Y3l7CQdceO4euhi/zreA00LguhWFKzy9grKUl8pH8RPCIwmOnpZncheGQsRxCEX4uua/w==
   dependencies:
-    "@expo/json-file" "^8.1.7"
+    "@expo/json-file" "^8.1.9"
     find-yarn-workspace-root "^1.2.1"
     fs-extra "^7.0.1"
     resolve-from "^5.0.0"
     slugify "^1.3.4"
 
-"@expo/image-utils@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.2.2.tgz#29f6c2fed7b03669189e7cdd22f9d3b8b37173fb"
-  integrity sha512-GTQ37sfCmTt5dspdP0R+Pek45YG4inZA30joLtNgBjZLLXdQDHMJ9nF9Pvm8E0YgQW2HaV8vouxyp6C+Y1QTxg==
+"@expo/image-utils@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.2.4.tgz#20dbde2ea0bc1fba8edbbbebe56524db787ef7ea"
+  integrity sha512-tj2f1tbZzZHSOz9uPABdR4nztVxHP3HLwHiHZZKLkrP51j3paQzNXpL3KJ2QV29SwepX1KCkEUO9qleu6zeblA==
   dependencies:
     "@expo/spawn-async" "1.5.0"
     semver "6.1.1"
   optionalDependencies:
     sharp-cli "1.10.0"
 
-"@expo/json-file@^8.1.7":
-  version "8.1.7"
-  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.1.7.tgz#5f3965a6c709c663d44da609a9c1163337d215f1"
-  integrity sha512-K+YVId3bWV/o9VHxSxIxfAwy+th6A4uh1nw7Q7WTUXJmyHY7OJBFyn/Itj24nTKoIzsFPF/xTgvrGtcCUtyfdQ==
+"@expo/json-file@^8.1.9":
+  version "8.1.9"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.1.9.tgz#cdd91ffacddbe108847ae14a73f2a5a8276fba7b"
+  integrity sha512-vl0EvL3fIajLzklPzafNLXEQXgYqi/Y4tqq5sPbUdkR1OyxfdixjVLdutt1bZ3un/obh6286MYa6OIm1LdYKOg==
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.44"
     fs-extra "^8.0.1"
@@ -1281,10 +1281,10 @@
     request "^2.81.0"
     uuid "^3.0.0"
 
-"@expo/osascript@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@expo/osascript/-/osascript-2.0.2.tgz#4433848080845b37684ca049474ba25cbfc7c4ee"
-  integrity sha512-bxoyxBRKzQ1T526dOp7e+wEnQ1ehdTIlcT2vPfS/7TncRiu81IJLXMseEw0Ik8isiP6pNmVG6JnqlZQAngT7oQ==
+"@expo/osascript@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@expo/osascript/-/osascript-2.0.4.tgz#e4169030c2913a64501997455be69d6d0e1d1155"
+  integrity sha512-2Kqh/SyXeOwW0Ky39ioiS8LPMU7zAg9S3WnkVu0VYiqW2V+w9IZSYsqVG6XkmfCJw7TVaFYHvyyS8cogOikgYQ==
   dependencies:
     "@expo/spawn-async" "^1.5.0"
     exec-async "^2.2.0"
@@ -1322,16 +1322,16 @@
   resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.9.9.tgz#88445052d4bfd0826f332f71a08f4402ad7ffdcd"
   integrity sha512-rz6gSbRrJI/g+JNgSunAX//TpedIpEGhLnB6H5uTtGl3Oqg/UkLIDlCjtHCdPrHAVRQqCR1qdT9k3AXbEYFV1w==
 
-"@expo/webpack-config@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.6.0.tgz#150ec83455333acb80ea682e2ee491a7c70247e2"
-  integrity sha512-TRb8eQGcnI/mhE/3Hsgq4Ur9wNJ+89g/J5Wdm5k+pAc0LzXF+FXQAuf90FbWip9fX8ULMkYO8iHi8erenQlLcw==
+"@expo/webpack-config@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.6.2.tgz#9b1dc45ec124bb8401b3659c0d87f4595a4df8c6"
+  integrity sha512-rfQ4fzVlNsEi3uY3wUDJFqAntQQShd2B3X2Rjeb5uPBrgmBbDEIj5R0vq/8KQK3Ug9wEg3rhmSkJnu5ABXwQYg==
   dependencies:
     "@babel/core" "^7.0.0"
     "@babel/polyfill" "^7.2.5"
     "@babel/runtime" "^7.3.4"
-    "@expo/config" "^2.1.0"
-    "@expo/webpack-pwa-manifest-plugin" "^1.2.0"
+    "@expo/config" "^2.1.2"
+    "@expo/webpack-pwa-manifest-plugin" "^1.2.2"
     babel-loader "^8.0.5"
     babel-preset-expo "^5.1.1"
     brotli-webpack-plugin "^1.1.0"
@@ -1342,6 +1342,7 @@
     copy-webpack-plugin "^5.0.0"
     css-loader "^2.1.1"
     deep-diff "^1.0.2"
+    eslint-loader "^2.2.1"
     file-loader "^3.0.1"
     find-yarn-workspace-root "^1.2.1"
     html-loader "^0.5.5"
@@ -1363,30 +1364,30 @@
     webpack-merge "^4.2.1"
     workbox-webpack-plugin "^3.6.3"
 
-"@expo/webpack-pwa-manifest-plugin@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@expo/webpack-pwa-manifest-plugin/-/webpack-pwa-manifest-plugin-1.2.0.tgz#c84afe88700ceccd79a53ba4399e8a79bdead6c6"
-  integrity sha512-ej1sxRmJStaC0dOdiM8+T5nACUdxJFuEVY7mBnrMgtmByRr/+vpmlL4UjOoNKDrCPmHW8gEC9RR1FrhA6M/8xQ==
+"@expo/webpack-pwa-manifest-plugin@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@expo/webpack-pwa-manifest-plugin/-/webpack-pwa-manifest-plugin-1.2.2.tgz#ffb49751b044abe4677697de5a90bc909e42f8fd"
+  integrity sha512-JYBkJeaankRtjq1pjkHdIrK6IrQ2wPSXFVE/iFCZ3Hf00pts12v108PadgcwkeVShXzJXgO9qMQjFz3jFhffmw==
   dependencies:
-    "@expo/image-utils" "^0.2.2"
+    "@expo/image-utils" "^0.2.4"
     css-color-names "^1.0.1"
     mime "^2.4.0"
     tempy "^0.3.0"
 
-"@expo/xdl@56.0.1-rc.1":
-  version "56.0.1-rc.1"
-  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-56.0.1-rc.1.tgz#962e249087aee877fd0fcb981d39ffbf0fca9abc"
-  integrity sha512-cNOxdudtPicprHIO2mIzykGxq3gT3C6hDEkZLUuH5G6rVgPXrTjdL9tRXUEWbw31IqxSZPySxqIObzjWprgvHQ==
+"@expo/xdl@56.1.2-rc.1":
+  version "56.1.2-rc.1"
+  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-56.1.2-rc.1.tgz#ca4005aafc3677ac047a9f93740f81fa412532a5"
+  integrity sha512-koDgCs+fNFCHdwDL58MFprd+0oVE1ZryrQ8HB4X5NTZG3Top5OWj4TxVOm09asCjriYZN3jsSESR2MAiT6YMVg==
   dependencies:
     "@expo/bunyan" "3.0.2"
-    "@expo/config" "^2.1.0"
-    "@expo/image-utils" "^0.2.2"
-    "@expo/json-file" "^8.1.7"
+    "@expo/config" "^2.1.2"
+    "@expo/image-utils" "^0.2.4"
+    "@expo/json-file" "^8.1.9"
     "@expo/ngrok" "2.4.3"
-    "@expo/osascript" "^2.0.2"
+    "@expo/osascript" "^2.0.4"
     "@expo/schemer" "^1.2.6"
     "@expo/spawn-async" "1.5.0"
-    "@expo/webpack-config" "^0.6.0"
+    "@expo/webpack-config" "^0.6.2"
     analytics-node "3.3.0"
     axios "0.19.0"
     chalk "2.4.1"
@@ -5169,6 +5170,17 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-loader@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-2.2.1.tgz#28b9c12da54057af0845e2a6112701a2f6bf8337"
+  integrity sha512-RLgV9hoCVsMLvOxCuNjdqOrUqIj9oJg8hF44vzJaYqsAHuY9G2YAeN3joQ9nxP0p5Th9iFSIpKo+SD8KISxXRg==
+  dependencies:
+    loader-fs-cache "^1.0.0"
+    loader-utils "^1.0.2"
+    object-assign "^4.0.1"
+    object-hash "^1.1.4"
+    rimraf "^2.6.1"
+
 eslint-scope@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.2.tgz#5f10cd6cabb1965bf479fa65745673439e21cb0e"
@@ -5703,6 +5715,15 @@ find-babel-config@^1.1.0:
   dependencies:
     json5 "^0.5.1"
     path-exists "^3.0.0"
+
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  integrity sha1-yN765XyKUqinhPnjHFfHQumToLk=
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
 
 find-cache-dir@^1.0.0:
   version "1.0.0"
@@ -8410,6 +8431,14 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
+loader-fs-cache@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.2.tgz#54cedf6b727e1779fd8f01205f05f6e88706f086"
+  integrity sha512-70IzT/0/L+M20jUlEqZhZyArTU6VKLRTYRDAYN26g4jfzpJqjipLL3/hgYpySqI9PwsVRHHFja0LfEmsx9X2Cw==
+  dependencies:
+    find-cache-dir "^0.1.1"
+    mkdirp "0.5.1"
+
 loader-runner@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -9179,7 +9208,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.x, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -9676,6 +9705,11 @@ object-copy@^0.1.0:
     copy-descriptor "^0.1.0"
     define-property "^0.2.5"
     kind-of "^3.0.3"
+
+object-hash@^1.1.4:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
+  integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.1.0"
@@ -10240,6 +10274,13 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  integrity sha1-ektQio1bstYp1EcFb/TpyTFM89Q=
+  dependencies:
+    find-up "^1.0.0"
 
 pkg-dir@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
Fixes https://github.com/expo/turtle/issues/115

### Description
The fix was actually implemented in `@expo/xdl` - https://github.com/expo/expo-cli/pull/869/files
In the case of Android debug builds we need to set the `DEVELOPMENT_URL` constant to the app's manifest url in `app/src/main/java/host/exp/exponent/generated/DetachBuildConstants.java`. Otherwise, the app crashes immediately after running it on a phone.