### PR TITLE
automate turtle-cli updates in the turtle-cli-example repo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -10,6 +10,13 @@ source_local() {
 
 source_local
 
+if [[ "$CI" != "true" && (-z "$GITHUB_TOKEN" || -z "$CIRCLE_API_USER_TOKEN") ]]; then
+  yellow=`tput setaf 3`
+  reset=`tput sgr0`
+  echo "${yellow}please set GITHUB_TOKEN and CIRCLE_API_USER_TOKEN env variables in .envrc.local file if you wish to release turtle-cli"
+  echo "run 'cp .envrc.local.example .envrc.local' if you don't have one yet and edit the new file${reset}"
+fi
+
 export NODE_ENV=development
 
 export EXPO_TURTLE_TOOLS_DIR="$(pwd)/tools"

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -1,0 +1,2 @@
+export GITHUB_TOKEN=__PUT_YOUR_GITHUB_TOKEN_HERE__ # follow the guide to create one: https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
+export CIRCLE_API_USER_TOKEN=__PUT_YOUR_CIRCLECI_API_TOKEN_HERE__ # create one here: https://circleci.com/account/api

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ shell.apk
 
 *.swp
 *.swo
+
+.envrc.local

--- a/.release-it.json
+++ b/.release-it.json
@@ -8,5 +8,8 @@
   },
   "github": {
     "release": true
+  },
+  "hooks": {
+    "after:release": "yarn release:update:turtle-cli-example"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ To submit a pull request:
 4. Wait for a review and adjust the code if necessary.
 
 ## Publishing a release
+- Make sure you have set `GITHUB_TOKEN` and `CIRCLE_API_USER_TOKEN` environment variables in `.envrc.local` file. If you don't have the file, run `cp .envrc.local.example .envrc.local` and edit the file.
 - To release a new version of `turtle-cli`, run `yarn release` command.
 - If you wish to release a new *beta* version of `turtle-cli`, run `yarn release:beta` instead.
 - Update [Changelog](CHANGELOG.md).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:smoke:android": "PLATFORM=android yarn test:smoke --testNamePattern=android",
     "test:smoke:ios": "PLATFORM=ios yarn test:smoke --testNamePattern=iOS",
     "release": "./scripts/release.sh",
-    "release:beta": "./scripts/releaseBeta.sh"
+    "release:beta": "./scripts/releaseBeta.sh",
+    "release:update:turtle-cli-example": "./scripts/updateTurtleCliExampleRepo.sh"
   },
   "husky": {
     "hooks": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,6 +4,14 @@ set -eo pipefail
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 
+if [[ -z "$GITHUB_TOKEN" || -z "$CIRCLE_API_USER_TOKEN" ]]; then
+  yellow=`tput setaf 3`
+  reset=`tput sgr0`
+  echo "${yellow}please set GITHUB_TOKEN and CIRCLE_API_USER_TOKEN env variables in .envrc.local file if you wish to release turtle-cli"
+  echo "run 'cp .envrc.local.example .envrc.local' if you don't have one yet and edit the new file${reset}"
+  exit 1
+fi
+
 $ROOT_DIR/node_modules/.bin/release-it
 echo
 echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/scripts/updateTurtleCliExampleRepo.sh
+++ b/scripts/updateTurtleCliExampleRepo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+DEPLOY_ENDPOINT_URL="https://circleci.com/api/v1.1/project/github/expo/turtle-cli-example/tree/updates-do-not-remove-me"
+
+curl -X POST \
+    --header "Content-Type: application/json" \
+    -u $CIRCLE_API_USER_TOKEN: \
+    -d '
+      {
+        "build_parameters": {
+          "CIRCLE_JOB": "update",
+          "TURTLE_TAG": "latest"
+        }
+      }' \
+    $DEPLOY_ENDPOINT_URL 2>/dev/null | jq -r .build_url


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
To automate the process of bumping `turtle-cli` version in https://github.com/expo/turtle-cli-example after each release.

### Description
- I created a CircleCI configuration in `turtle-cli-example` repository and committed it to a new branch - https://github.com/expo/turtle-cli-example/tree/updates-do-not-remove-me. The configuration contains a job (`update`) which bumps the `turtle-cli` version on `master` branch and pushes the commit to the remote repository.
- I created a script for triggering update jobs in `turtle-cli-example` and added a `after:release` hook to `realease-it` configuration which runs the script.
- I added a warning which shows up when a developer hasn't set `GITHUB_TOKEN` and `CIRCLE_API_USER_TOKEN` env variables.