### PR TITLE
fix ios archive builds

### DIFF
--- a/src/builders/ios/context.ts
+++ b/src/builders/ios/context.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 
-import { IosShellApp } from '@expo/xdl';
+import { ExponentTools, IosShellApp } from '@expo/xdl';
 import { v4 as uuidv4 } from 'uuid';
 
 import { formatShellAppDirectory } from 'turtle/builders/utils/ios/workingdir';
@@ -41,6 +41,7 @@ export function createBuilderContext(job: IJob): IContext {
 
   const sdkVersion = sdkVersionFromJob || sdkVersionFromManifest;
   const workingDir = formatShellAppDirectory({ sdkVersion, buildType: buildType! });
+  const majorSdkVersion = ExponentTools.parseSdkMajorVersion(sdkVersion);
 
   const context: any = {
     appDir: join(config.directories.temporaryFilesRoot, appUUID),
@@ -84,13 +85,24 @@ export function createBuilderContext(job: IJob): IContext {
       'Applications',
       `${EXPOKIT_APP}.app`,
     );
-    context.workspacePath = path.join(
-      workingDir,
-      'shellAppWorkspaces',
-      'ios',
-      'default',
-      `${EXPOKIT_APP}.xcworkspace`,
-    );
+    if (majorSdkVersion >= 33) {
+      context.workspacePath = path.join(
+        workingDir,
+        'shellAppWorkspaces',
+        'default',
+        'ios',
+        `${EXPOKIT_APP}.xcworkspace`,
+      );
+    } else {
+      context.workspacePath = path.join(
+        workingDir,
+        'shellAppWorkspaces',
+        'ios',
+        'default',
+        `${EXPOKIT_APP}.xcworkspace`,
+      );
+    }
+
   } else if (buildType === IOS_BUILD_TYPES.CLIENT) {
     context.outputPath = join(context.appDir, 'archive.xcarchive');
     context.uploadPath = join(context.buildDir, 'archive.ipa');


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
Because of this PR - https://github.com/expo/expo-cli/pull/720/files - we need to change the workspace path for sdk >= 33 builds.

### Description
I changed the workspace path for all builds of sdk 33 and newer.
