### PR TITLE
add xcode license check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Android shell app for SDK34.
+- Xcode license check for iOS builds.
 ### Fixed
 - Setting `Constants.nativeAppVersion` for Android standalone builds (actually fixed in [expo/expo-cli#878](https://github.com/expo/expo-cli/pull/878)).
 

--- a/src/bin/setup/utils/toolsDetector.ts
+++ b/src/bin/setup/utils/toolsDetector.ts
@@ -19,7 +19,7 @@ export async function ensureToolsAreInstalled(tools: IToolDefinition[]) {
     try {
       if (testFn) {
         if (!await testFn()) {
-          throw new Error('Required tool doesn\'t exist');
+          throw new Error('Required tool is not properly installed');
         }
       } else {
         await which(command);


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
Fixes https://github.com/expo/turtle/issues/117

### Description
A way of detecting if a user accepted the Xcode license is to run `ibtool --version` and check whether it doesn't print any warnings/errors. I added this check to the setup phase of turtle-cli iOS builds. I also added a warning with instructions on how to fix the issue.