### PR TITLE
fix passing android config to builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Xcode license check for iOS builds.
 ### Fixed
 - Setting `Constants.nativeAppVersion` for Android standalone builds (actually fixed in [expo/expo-cli#878](https://github.com/expo/expo-cli/pull/878)).
+- Passing `expo.android.config` object from `app.json` to the Android builder.
 
 ## [0.8.11] - 2019-07-16
 ### Fixed

--- a/src/bin/utils/builder.ts
+++ b/src/bin/utils/builder.ts
@@ -94,7 +94,7 @@ const buildJobObject = async (
 ) => {
   const job = {
     config: {
-      ..._.get(appJSON, 'expo.ios.config', {}),
+      ..._.get(appJSON, `expo.${platform}.config`, {}),
       buildType,
       ...(platform === 'android' ? { buildMode } : {}),
       releaseChannel,


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
Fixes https://github.com/expo/turtle/issues/122

### Description
I fixed passing `expo.android.config` object to the Android builder (we were always passing `expo.ios.config` instead).
