### PR TITLE
handle invalid build jobs in better way

### DIFF
--- a/src/builders/ios/index.ts
+++ b/src/builders/ios/index.ts
@@ -61,4 +61,4 @@ async function cleanup(ctx: IContext) {
 }
 
 const getTemporaryDirs = (ctx: IContext) =>
-  Object.values(pick(ctx, ['appDir', 'provisioningProfileDir']));
+  Object.values(pick(ctx, ['appDir', 'provisioningProfileDir'])) as string[];

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,7 +55,7 @@ async function main() {
     try {
       await doJob();
     } catch (err) {
-      logger.error({ err }, 'Failed to do a job');
+      logger.error({ err }, 'Failed to process a job');
     }
   }
 }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -2,6 +2,9 @@ import * as schemas from 'turtle/jobsSchemas';
 
 export async function sanitizeJob(job: any) {
   const schema = (schemas as any)[job.platform];
+  if (!schema) {
+    throw new Error(`Unsupported platform: ${job.platform}`);
+  }
   const { error, value } = schema.validate(job, { stripUnknown: true });
   if (error) {
     throw error;


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

https://github.com/expo/universe/issues/3739

### Description
We don't mark a build job as errored in the database when the job JSON is invalid. I added this behavior and also added a more detailed log in that case. 