### PR TITLE
add shellAppSdkVersion param to iosShellAppBuilder

### DIFF
--- a/src/builders/utils/ios/shellAppBuilder.ts
+++ b/src/builders/utils/ios/shellAppBuilder.ts
@@ -36,6 +36,7 @@ export default async function runShellAppBuilder(ctx: IContext, job: IJob): Prom
     manifest,
     output: ctx.outputPath,
     verbose: true,
+    shellAppSdkVersion: sdkVersion,
   };
   if (buildType === IOS_BUILD_TYPES.CLIENT) {
     Object.assign(shellAppParams, {


### PR DESCRIPTION
# why
- when we bumped the XDL version, it included some changes that causes the manifest not to be read when we write the `entitlements` file
- this is causing a lot of problems, because people are unable to submit their apps to the AppStore without the proper values in the `entitlements` file.

# how 
- The check [here](https://github.com/expo/expo-cli/blob/master/packages/xdl/src/detach/IosNSBundle.ts#L161) is returning `false` and preventing us from reading in the manifest.
- This is caused by this check [here](https://github.com/expo/expo-cli/blob/master/packages/xdl/src/detach/StandaloneContext.ts#L23) because turtle doesn't currently pass in the new parameter `shellAppSdkVersion` to the `IosShellAppBuilder`

# related issues
https://twitter.com/defquan/status/1195076300056084480
https://forums.expo.io/t/invalid-code-signing-entitlements-value-for-key-com-apple-developer-associated-domains/30061

# test
- [x] built turtle locally and can produce .ipa with proper entitlement keys added now