### PR TITLE
Fix expo.owner not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.12.12] - 2019-11-22
+
+### Fixed
+
+- A bug that caused `expo.owner` value not to be used if defined.
+
 ## [0.12.11] - 2019-11-20
 
 ### Added
 
-- Bumped `travelling-fastlane` to 1.11.0
+- Bumped `traveling-fastlane` to 1.11.0
 
 ## [0.12.10] - 2019-11-15
 

--- a/src/bin/utils/builder.ts
+++ b/src/bin/utils/builder.ts
@@ -92,6 +92,7 @@ const buildJobObject = async (
   { releaseChannel, buildType, buildMode, username, publicUrl, projectDir }: any,
   credentials: any,
 ) => {
+  const experienceName = `@${_.get(appJSON, 'expo.owner', username)}/${_.get(appJSON, 'expo.slug')}`;
   const job = {
     config: {
       ..._.get(appJSON, `expo.${platform}.config`, {}),
@@ -106,7 +107,7 @@ const buildJobObject = async (
     platform,
     projectDir,
     sdkVersion: _.get(appJSON, 'expo.sdkVersion'),
-    experienceName: `@${username}/${_.get(appJSON, 'expo.slug')}`,
+    experienceName,
     ...(credentials && { credentials }),
   };
   const url = getExperienceUrl(job.experienceName, job.config.publicUrl);


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
Reported internally (cc @paulmichalak)

### Description
I changed the logic for making `experienceName` if the `expo.owner` field is defined.