### PR TITLE
Add missing RCTAssetsLibraryRequestHandler to iOS tarball for SDK36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.13.5] - 2019-12-17
+
+### Fixed
+
+- Fixed issue with missing request handler for assets-library urls.
+
 ## [0.13.4] - 2019-12-13
 
 ### Added

--- a/shellTarballs/ios/sdk36
+++ b/shellTarballs/ios/sdk36
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-1d9cef3e92482314ed6282d53a60022f878900e2.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-7c0999cf6d266e8bfe2d368d863a5a1b7ed73e88.tar.gz


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

Fixes https://github.com/expo/expo/issues/6524

### Description

Updating iOS shell tarball for SDK36.
