### PR TITLE
bump traveling-fastlane to 1.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [0.13.7] - 2029-01-15
+## [0.13.7] - 2020-01-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.13.7] - 2029-01-15
+
+### Added
+
+- Bumped `traveling-fastlane` to 1.11.4 to update CA certs
+
 ## [0.13.6] - 2019-12-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -130,6 +130,6 @@
     "which": "^1.3.1"
   },
   "optionalDependencies": {
-    "@expo/traveling-fastlane-darwin": "1.11.0"
+    "@expo/traveling-fastlane-darwin": "1.11.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,10 +1364,10 @@
   dependencies:
     cross-spawn "^6.0.5"
 
-"@expo/traveling-fastlane-darwin@1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.0.tgz#88f09e2332f2103fafac4759bbbc86832633768a"
-  integrity sha512-owQdOQ0Ag4XE9LtXQ0p1fWwWqa0uhJvEKEmvb5ugPbdkT8BSs92TNfULHPMkGohcHlB0/Q+VXTUbSnP4zczKbQ==
+"@expo/traveling-fastlane-darwin@1.11.4":
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.4.tgz#bc83ea2a3c8fa2cb1c7daedf1514c5839b4f1f45"
+  integrity sha512-1rNq4yMHGfmYhUJuBH5lKpmHVAa5QjgXbv3MoMqsFrlnwzDaq4qHSs6s/RWHw+gmk5lASEhmW32ALArAxX9ceA==
 
 "@expo/webpack-config@^0.10.6":
   version "0.10.6"


### PR DESCRIPTION
# why
CA certs have expired on previous versions of traveling fastlane and `https` requests made with it will fail (for example, see [this](https://staging.expo.io/builds/a63ef90c-9d60-46a8-9c04-f92560924c56))