### PR TITLE
preinstall gradle 4.10.2 and 5.6.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # see docker-base/Dockerfile to learn what's installed in the turtle-android-base image
-FROM gcr.io/exponentjs/turtle-android-base:0.1.2
+FROM gcr.io/exponentjs/turtle-android-base:0.1.3
 
 ADD . /app/turtle
 

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -61,10 +61,27 @@ RUN /tmp/configureAndroidSdk.sh --install-all-platforms
 # Support Gradle
 ENV TERM dumb
 
-# Install gradle
-RUN wget https://services.gradle.org/distributions/gradle-4.4-all.zip
-RUN unzip -qq gradle-4.4-all.zip
-RUN mv gradle-4.4 /usr/local
-RUN rm gradle-4.4-all.zip
-ENV GRADLE_HOME /usr/local/gradle-4.4
+# Install gradle 5.6.3
+RUN wget https://services.gradle.org/distributions/gradle-5.6.3-all.zip
+RUN unzip -qq gradle-5.6.3-all.zip
+RUN cp -r gradle-5.6.3 /usr/local
+
+RUN mkdir -p /root/.gradle/wrapper/dists/gradle-5.6.3-all/7wpcz6s7ut7bllr9k6e1hazxc
+RUN mv gradle-5.6.3-all.zip /root/.gradle/wrapper/dists/gradle-5.6.3-all/7wpcz6s7ut7bllr9k6e1hazxc
+RUN mv gradle-5.6.3 /root/.gradle/wrapper/dists/gradle-5.6.3-all/7wpcz6s7ut7bllr9k6e1hazxc
+RUN touch /root/.gradle/wrapper/dists/gradle-5.6.3-all/7wpcz6s7ut7bllr9k6e1hazxc/gradle-5.6.3-all.zip.ok
+RUN touch /root/.gradle/wrapper/dists/gradle-5.6.3-all/7wpcz6s7ut7bllr9k6e1hazxc/gradle-5.6.3-all.zip.lck
+RUN chmod 755 /root/.gradle/wrapper/dists/gradle-5.6.3-all/7wpcz6s7ut7bllr9k6e1hazxc/gradle-5.6.3/bin/gradle
+
+ENV GRADLE_HOME /usr/local/gradle-5.6.3
 ENV PATH ${GRADLE_HOME}/bin:$PATH
+
+# Install gradle 4.10.2
+RUN wget https://services.gradle.org/distributions/gradle-4.10.2-all.zip
+RUN mkdir -p /root/.gradle/wrapper/dists/gradle-4.10.2-all/9fahxiiecdb76a5g3aw9oi8rv
+RUN unzip -qq gradle-4.10.2-all.zip
+RUN mv gradle-4.10.2-all.zip /root/.gradle/wrapper/dists/gradle-4.10.2-all/9fahxiiecdb76a5g3aw9oi8rv
+RUN mv gradle-4.10.2 /root/.gradle/wrapper/dists/gradle-4.10.2-all/9fahxiiecdb76a5g3aw9oi8rv
+RUN touch /root/.gradle/wrapper/dists/gradle-4.10.2-all/9fahxiiecdb76a5g3aw9oi8rv/gradle-4.10.2-all.zip.ok
+RUN touch /root/.gradle/wrapper/dists/gradle-4.10.2-all/9fahxiiecdb76a5g3aw9oi8rv/gradle-4.10.2-all.zip.lck
+RUN chmod 755 /root/.gradle/wrapper/dists/gradle-4.10.2-all/9fahxiiecdb76a5g3aw9oi8rv/gradle-4.10.2/bin/gradle


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
Every first build on a new builder requires downloading the appropriate Gradle version.

### Description
I preinstalled Gradle 4.10.2 (for SDK <36) and 5.6.3 (for SDK 36) in the builder container.