### PR TITLE
[android] update sdk37 tarball so it doesn't use jq internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.14.2] - 2020-04-03
+
+### Fixed
+
+- A fix for Android SDK 37 - `check-dynamic-macros-android.sh` doesn't use `jq` anymore.
+
 ## [0.14.1] - 2020-04-01
 
 ### Changed

--- a/shellTarballs/android/sdk37
+++ b/shellTarballs/android/sdk37
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-685a981a19e39b8b6d1ea3a28dee1c0c35a6959a.tar.gz
+s3://exp-artifacts/android-shell-builder-701650df1bf19da5e223688a3773a33f6f540fa3.tar.gz

--- a/shellTarballs/android/sdk37
+++ b/shellTarballs/android/sdk37
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-1a6203cf1555c3b956a311ed539eafeb7594f030.tar.gz
+s3://exp-artifacts/android-shell-builder-685a981a19e39b8b6d1ea3a28dee1c0c35a6959a.tar.gz


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
This is a better solution for https://github.com/expo/turtle/issues/200
I removed the `jq` usage from `check-dynamic-macros-android.sh`.

### Description
I generated a new shell app from `expo/expo#sdk-37` branch and updated it here.
