### PR TITLE
improve deployment speed for android workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN ln -s /app/turtle/workingdir /app/workingdir && \
     for SDK_VERSION in `ls /app/workingdir/android/`; do \
       echo "preparing $SDK_VERSION shell app" && \
       cd /app/workingdir/android/$SDK_VERSION && \
-      mv packages packages-non-worksapce && \
+      mv packages non-workspace-packages && \
       yarn install && \
-      mv packages-non-worksapce packages ; \
+      mv non-workspace-packages packages ; \
     done
 
 ENV NODE_ENV "production"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,26 +3,21 @@ FROM gcr.io/exponentjs/turtle-android-base:0.4.0
 
 ADD . /app/turtle
 
-RUN mv /app/turtle/workingdir /app && \
+WORKDIR /app/turtle
+
+RUN ./scripts/fetchRemoteTarballs.sh android
+
+RUN ln -s /app/turtle/workingdir /app/workingdir && \
     for SDK_VERSION in `ls /app/workingdir/android/`; do \
       echo "preparing $SDK_VERSION shell app" && \
       cd /app/workingdir/android/$SDK_VERSION && \
-      if [ -f universe-package.json ]; then \
-      mv package.json exponent-package.json && \
-      mv universe-package.json package.json && \
+      mv packages packages-non-worksapce && \
       yarn install && \
-      mv package.json universe-package.json && \
-      mv exponent-package.json package.json; \
-      else \
-      yarn install; \
-      fi \
-    ; done && \
-    mv /app/workingdir /app/turtle
+      mv packages-non-worksapce packages ; \
+    done
 
 ENV NODE_ENV "production"
 ENV TURTLE_WORKING_DIR_PATH /app/turtle/workingdir/
-
-WORKDIR /app/turtle
 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ PLATFORM=$1
 yarn
 yarn run build
 if [ "$PLATFORM" = "android" ]; then
-  $ROOT_DIR/scripts/android/fetchRemoteAndroidTarball.sh
+  echo "shellapps will be fetched inside Dockerfile"
 elif [ "$PLATFORM" = "ios" ]; then
   $ROOT_DIR/scripts/ios/fetchRemoteIosTarball.sh
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,7 +14,7 @@ PLATFORM=$1
 yarn
 yarn run build
 if [ "$PLATFORM" = "android" ]; then
-  echo "shellapps will be fetched inside Dockerfile"
+  echo "shell apps will be fetched when building a Docker image"
 elif [ "$PLATFORM" = "ios" ]; then
   $ROOT_DIR/scripts/ios/fetchRemoteIosTarball.sh
 fi


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Improve deployment speed from 1h 30 min to 45 min

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

- skip dependency installation inside `packages` directory
- fetch shellapps inside docker build (`ADD` is faster)
- switch from using `mv` to symlink to install yarn dependecies