### PR TITLE
Install only production dependencies in shell apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Turtle no longer installs all dependencies of shell apps projects — only the production dependencies are installed now.
+
 ## [0.14.6] - 2020-04-09
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN ln -s /app/turtle/workingdir /app/workingdir && \
       echo "preparing $SDK_VERSION shell app" && \
       cd /app/workingdir/android/$SDK_VERSION && \
       mv packages non-workspace-packages && \
-      yarn install --ignore-scripts && \
+      # --prod requires --ignore-scripts (otherwise
+      # expo-yarn-workspaces errors as missing)
+      yarn install --ignore-scripts --prod && \
       mv non-workspace-packages packages ; \
     done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN ln -s /app/turtle/workingdir /app/workingdir && \
       echo "preparing $SDK_VERSION shell app" && \
       cd /app/workingdir/android/$SDK_VERSION && \
       mv packages non-workspace-packages && \
+      # Keep in sync with src/bin/setup/android/index.ts#_installNodeModules
       # --prod requires --ignore-scripts (otherwise
       # expo-yarn-workspaces errors as missing)
       yarn install --ignore-scripts --prod && \

--- a/src/bin/setup/android/index.ts
+++ b/src/bin/setup/android/index.ts
@@ -101,7 +101,9 @@ async function _shellAppPostDownloadAction(sdkVersion: string, workingdir: strin
 async function _installNodeModules(cwd: string) {
   l.info(`installing dependencies in ${cwd} directory...`);
   const command = await _shouldUseYarnOrNpm();
-  await ExponentTools.spawnAsyncThrowError(command, ['install', '--production'], {
+  // Keep in sync with /Dockerfile
+  // --prod requires --ignore-scripts (otherwise expo-yarn-workspaces errors as missing)
+  await ExponentTools.spawnAsyncThrowError(command, ['install', '--ignore-scripts', '--production'], {
     pipeToLogger: true,
     loggerFields: LOGGER_FIELDS,
     cwd,

--- a/src/bin/setup/android/index.ts
+++ b/src/bin/setup/android/index.ts
@@ -101,7 +101,7 @@ async function _shellAppPostDownloadAction(sdkVersion: string, workingdir: strin
 async function _installNodeModules(cwd: string) {
   l.info(`installing dependencies in ${cwd} directory...`);
   const command = await _shouldUseYarnOrNpm();
-  await ExponentTools.spawnAsyncThrowError(command, ['install'], {
+  await ExponentTools.spawnAsyncThrowError(command, ['install', '--production'], {
     pipeToLogger: true,
     loggerFields: LOGGER_FIELDS,
     cwd,


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

The build process doesn't use any of the `devDependencies` of shell apps and installing them makes the process slower and using more memory.

### Description

Added the `--prod` flag to `yarn install` happening inside shell apps so Yarn installs only the real dependencies of the project. This omits dependencies like:
- `babel-core`, `prettier`, `eslint` — we won't transpile, analyze, prettify JS when building the project,
- `expo-cli` — we could use `expo-cli` when building the project, but we don't (`expotools` are used and they are installed in the shell app)
- `expo-yarn-workspaces` — the `--ignore-scripts` removes the need for `expo-yarn-workspaces`

### Test plan

I have tested these changes as part of https://github.com/expo/turtle/pull/209. I have built two apps on SDK37 and both were built successfully.