### PR TITLE
[android] Build only the app artifact and not all available libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Updated `@expo/xdl` to 57.8.30 (scoped the build command so it only builds the `:app` Android sub-project and not all the sub-projects available, [PR](https://github.com/expo/expo-cli/pull/1937)).
+
 ## [0.14.8] - 2020-04-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "@expo/config": "^3.0.5",
     "@expo/spawn-async": "^1.4.2",
-    "@expo/xdl": "57.8.29",
+    "@expo/xdl": "57.8.30",
     "@google-cloud/logging-bunyan": "^2.0.3",
     "async-retry": "^1.2.1",
     "aws-sdk": "^2.226.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,10 +1470,10 @@
   resolved "https://registry.yarnpkg.com/@expo/traveling-fastlane-darwin/-/traveling-fastlane-darwin-1.11.4.tgz#bc83ea2a3c8fa2cb1c7daedf1514c5839b4f1f45"
   integrity sha512-1rNq4yMHGfmYhUJuBH5lKpmHVAa5QjgXbv3MoMqsFrlnwzDaq4qHSs6s/RWHw+gmk5lASEhmW32ALArAxX9ceA==
 
-"@expo/webpack-config@0.11.25":
-  version "0.11.25"
-  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.11.25.tgz#0bba187a324caa164ff5f4ec3b974be0cfec7166"
-  integrity sha512-Tr8i7qKE22NVhu2s7cZrl5FRyiA18eKUyoWu1j4nAAo5rT2ANpE7nUaDfeGdTrFSPxti49byIFB2eFBS/bqHIQ==
+"@expo/webpack-config@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.12.0.tgz#c45abe178695105ce889345bb3de8f55b6f82dbb"
+  integrity sha512-ZrMb9+LicCvHbT4KJOHpNDEb/UUJHeJ6PdJ8Y6iXVMrjqb/Vu/YbRT+kT7nCxoF0jiOmkvahi1F40rRadPZ8VQ==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/runtime" "7.9.0"
@@ -1507,10 +1507,10 @@
     worker-loader "^2.0.0"
     yup "^0.27.0"
 
-"@expo/xdl@57.8.29":
-  version "57.8.29"
-  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-57.8.29.tgz#cb32e4df8b56da05d97781d125b13776d76dcc65"
-  integrity sha512-Yvh1BO/LWoFO4mAVgvCttzSQp8FWTG6QEXUGqErcJGfV+tTJ1jTunSwXv5sPK3lYenQt459ChRLwJ6WPycMNVw==
+"@expo/xdl@57.8.30":
+  version "57.8.30"
+  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-57.8.30.tgz#7e042be6e6a30f69ae343449b89d483bae359b5c"
+  integrity sha512-R4+5y7zYJMxYuP9s9y+qN8a89NJXGQWXF+8nNxlNrSFk+UNu3U1t7yx8d4S3yI4QZKeHVSI6HJLvkvzliO2VEw==
   dependencies:
     "@expo/bunyan" "3.0.2"
     "@expo/config" "3.1.2"
@@ -1521,7 +1521,7 @@
     "@expo/plist" "0.0.3"
     "@expo/schemer" "1.3.9"
     "@expo/spawn-async" "1.5.0"
-    "@expo/webpack-config" "0.11.25"
+    "@expo/webpack-config" "0.12.0"
     analytics-node "3.3.0"
     axios "0.19.0"
     boxen "4.1.0"


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

I have noticed that not only the `app` project is being built on Turtle, but all the projects. (cross-posting from https://github.com/expo/expo-cli/pull/1937)

### Description

I've scoped the Gradle command to only build/assemble the `:app` project. It should be safe to do for all SDKs, since on all SDKs the app project was called `app`.

Published an alpha version of XDL to NPM, upgraded Turtle to it, deployed to staging and ran the build. It was over a minute faster than without this change ([new](https://staging.expo.io/dashboard/sjchmiela/builds/5c386cef-e808-49d3-91d8-9ce42af77c36) vs [old](https://staging.expo.io/dashboard/sjchmiela/builds/3d36340e-6ae1-4476-91cb-07d81f1edd1e)). (cross-posting from https://github.com/expo/expo-cli/pull/1937)