### PR TITLE
configure turtle to use the redis ca certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ google-cloud-credentials.json
 /workingdir/*
 /artifacts/*
 .history
+.vscode/
 
 shell.apk
 .secrets*

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,20 +8,21 @@ WORKDIR /app/turtle
 RUN ./scripts/fetchRemoteTarballs.sh android
 
 RUN ln -s /app/turtle/workingdir /app/workingdir && \
-    for SDK_VERSION in `ls /app/workingdir/android/`; do \
-      echo "preparing $SDK_VERSION shell app" && \
-      cd /app/workingdir/android/$SDK_VERSION && \
-      mv packages non-workspace-packages && \
-      # Keep in sync with src/bin/setup/android/index.ts#_installNodeModules
-      # --prod requires --ignore-scripts (otherwise
-      # expo-yarn-workspaces errors as missing)
-      yarn install --ignore-scripts --prod && \
-      mv non-workspace-packages packages ; \
-    done
+  for SDK_VERSION in `ls /app/workingdir/android/`; do \
+  echo "preparing $SDK_VERSION shell app" && \
+  cd /app/workingdir/android/$SDK_VERSION && \
+  mv packages non-workspace-packages && \
+  # Keep in sync with src/bin/setup/android/index.ts#_installNodeModules
+  # --prod requires --ignore-scripts (otherwise
+  # expo-yarn-workspaces errors as missing)
+  yarn install --ignore-scripts --prod && \
+  mv non-workspace-packages packages ; \
+  done
 
 ENV NODE_ENV "production"
 ENV TURTLE_WORKING_DIR_PATH /app/turtle/workingdir/
 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+ADD redislabs_ca.pem /var/run/config/redislabs-tls/redislabs_ca.pem
 
 CMD ["/usr/bin/supervisord"]

--- a/k8s/android/turtle-deployment.template.yml
+++ b/k8s/android/turtle-deployment.template.yml
@@ -152,6 +152,8 @@ spec:
             value: '-Xms2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseG1GC'
           - name: GRADLE_OPTS
             value: '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xms2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseG1GC"'
+          - name: REDIS_CA_CERTIFICATE
+            value: '/var/run/config/redislabs-tls/redislabs_ca.pem'
         resources:
           requests:
             memory: "8192Mi"

--- a/redislabs_ca.pem
+++ b/redislabs_ca.pem
@@ -1,0 +1,1 @@
+this is just a placeholder to simplify deployments

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
@@ -44,8 +45,17 @@ export default {
     intervalMs: env('DATADOG_INTERVAL_MS', 5 * 60 * 1000),
   },
   redis: {
-    url: env('REDIS_URL'),
-    configUrl: env('REDIS_CONFIG_URL'),
+    main: {
+      url: env('REDIS_URL'),
+      caCertificate: envTransform(
+        'REDIS_CA_CERTIFICATE',
+        null,
+        (caCertificate: string) => caCertificate && fs.readFileSync(caCertificate),
+      ),
+    },
+    turtle: {
+      url: env('REDIS_CONFIG_URL'),
+    },
   },
   logger: {
     level: env('LOGGER_LEVEL', 'info'),
@@ -81,7 +91,7 @@ export default {
     androidDependenciesDir: env(
       'TURTLE_ANDROID_DEPENDENCIES_DIR',
       path.join(os.homedir(), '.turtle/androidDependencies'),
-      ),
+    ),
     tempS3LogsDir: env('TURTLE_TEMP_S3_LOGS_DIR', '/tmp/logs'),
     fakeUploadDir: envOptional('TURTLE_FAKE_UPLOAD_DIR'),
     temporaryFilesRoot: env(


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

Part of https://github.com/expo/universe/issues/5226

The main Redis cache now requires TLS (rediss) connections. Turtle still uses non-TLS redis connections, which means it cannot connect to the Redis instance anymore.

### Description

The Redis client is now using the CA certificate if it's defined.
