### PR TITLE
Allow override of protocol validation in--public-url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `--allow-non-https-public-url` to allow bypass of protocol validation on `--public-url`.
+
 ## [0.16.0] - 2020-06-25
 
 ### Added

--- a/src/bin/commands/build/index.ts
+++ b/src/bin/commands/build/index.ts
@@ -15,7 +15,8 @@ function setCommonCommandOptions(cmd: any) {
     .option('-o --output <output-file-path>', 'output file path')
     .option(
       '--public-url <url>',
-      'the URL of an externally hosted manifest (for self-hosted apps), only HTTPS URLs are supported unless --allow-non-https-public-url is also set!',
+      'the URL of an externally hosted manifest (for self-hosted apps), only HTTPS URLs are supported unless '
+      + '--allow-non-https-public-url is also set!',
     )
     .option(
       '--allow-non-https-public-url',

--- a/src/bin/commands/build/index.ts
+++ b/src/bin/commands/build/index.ts
@@ -15,7 +15,11 @@ function setCommonCommandOptions(cmd: any) {
     .option('-o --output <output-file-path>', 'output file path')
     .option(
       '--public-url <url>',
-      'the URL of an externally hosted manifest (for self-hosted apps), only HTTPS URLs are supported!',
+      'the URL of an externally hosted manifest (for self-hosted apps), only HTTPS URLs are supported unless --allow-non-https-public-url is also set!',
+    )
+    .option(
+      '--allow-non-https-public-url',
+      'allows non-HTTPS URLs in --public-url; this should only be used when building an unpublished application',
     )
     .option(
       '--release-channel <channel-name>',

--- a/src/bin/utils/builder.ts
+++ b/src/bin/utils/builder.ts
@@ -57,7 +57,7 @@ export function createBuilderAction({
         );
       }
 
-      if (cmd.publicUrl) {
+      if (cmd.publicUrl && !cmd.allowNonHttpsPublicUrl) {
         const parsedPublicUrl = _url.parse(cmd.publicUrl);
         if (parsedPublicUrl.protocol !== 'https:') {
           throw new ErrorWithCommandHelp('--public-url is invalid - only HTTPS urls are supported');


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This adds a new `--allow-non-https-public-url` which disables validation requiring that `--public-url` have a protocol of `https://`.  This allows for unpublished builds as was possible before this validation was added (see https://github.com/expo/turtle/issues/210).

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->

I have applied the changes manually to my local node_modules and they appear to work.  I still cannot build master.