### PR TITLE
build:android - allow for passing custom gradle args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `--gradle-args` option for `turtle build:android` which makes it possible to specify custom Gradle arguments.
+
 ### Changed
 
 - Gradle Wrapper doesn't print when dots when the appropriate version of Gradle is being downloaded.

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@expo/config": "^3.2.14",
     "@expo/spawn-async": "^1.4.2",
-    "@expo/xdl": "57.9.25-alpha.0",
+    "@expo/xdl": "57.9.25-alpha.1",
     "@google-cloud/logging-bunyan": "^2.0.3",
     "async-retry": "^1.2.1",
     "aws-sdk": "^2.226.1",

--- a/src/bin/commands/build/android.ts
+++ b/src/bin/commands/build/android.ts
@@ -29,6 +29,11 @@ export default (program: any, setCommonCommandOptions: any) => {
       /^(debug|release)$/i,
       'release',
     )
+    .option(
+      '--gradle-args <gradle-args>',
+      'optional arguments passed to gradle, make sure to surround them with double quotes'
+      + ' (e.g.: --gradle-args "--stacktrace --debug")',
+    )
     .description(
       'Build a standalone APK or App Bundle for your project, either signed and ready for submission to'
       + ' the Google Play Store or in debug mode.',

--- a/src/bin/utils/builder.ts
+++ b/src/bin/utils/builder.ts
@@ -79,7 +79,7 @@ export function createBuilderAction({
       await setup(platform, sdkVersion);
       const credentials = await prepareCredentials(cmd);
       const rawJob = {
-        ...await buildJobObject(platform, projectConfig, args, credentials, sdkVersion),
+        ...await buildJobObject(cmd, platform, projectConfig, args, credentials, sdkVersion),
         ...cmd.buildDir && { fakeUploadDir: ProjectUtils.resolveAbsoluteDir(cmd.buildDir) },
         ...cmd.output && { fakeUploadBuildPath: ProjectUtils.resolveAbsoluteDir(cmd.output) },
       };
@@ -113,6 +113,7 @@ function getExpoSDKVersionSafely(projectDir: string, projectConfig: ProjectConfi
 }
 
 const buildJobObject = async (
+  cmd: any,
   platform: 'android' | 'ios',
   projectConfig: ProjectConfig,
   { releaseChannel, buildType, buildMode, username, publicUrl, projectDir }: any,
@@ -125,11 +126,12 @@ const buildJobObject = async (
     config: {
       ...(projectConfig.exp?.[platform]?.config || {}),
       buildType,
-      ...(platform === 'android' ? { buildMode } : {}),
       releaseChannel,
-      ...(platform === 'ios' ? { bundleIdentifier: projectConfig.exp?.ios?.bundleIdentifier } : {}),
-      ...(platform === 'android' ? { androidPackage: projectConfig.exp?.android?.package } : {}),
       publicUrl,
+      ...(platform === 'android' && cmd.gradleArgs ? { gradleArgs: cmd.gradleArgs.split(' ') } : {}),
+      ...(platform === 'android' ? { buildMode } : {}),
+      ...(platform === 'android' ? { androidPackage: projectConfig.exp?.android?.package } : {}),
+      ...(platform === 'ios' ? { bundleIdentifier: projectConfig.exp?.ios?.bundleIdentifier } : {}),
     },
     id: uuid.v4(),
     platform,

--- a/src/builders/android.ts
+++ b/src/builders/android.ts
@@ -34,8 +34,8 @@ export default async function buildAndroid(jobData: IJob): Promise<IJobResult> {
     ...config.builder.fakeUpload && {
       fakeUploadBuildPath:
         jobData.fakeUploadBuildPath
-        ? jobData.fakeUploadBuildPath
-        : path.join(jobData.fakeUploadDir || config.directories.fakeUploadDir, fakeUploadFilename),
+          ? jobData.fakeUploadBuildPath
+          : path.join(jobData.fakeUploadDir || config.directories.fakeUploadDir, fakeUploadFilename),
     },
   });
 
@@ -103,6 +103,7 @@ async function runShellAppBuilder(
       modules: enabledModules,
       buildType: jobData.config.buildType,
       buildMode: jobData.config.buildMode,
+      gradleArgs: jobData.config.gradleArgs,
     });
   } catch (err) {
     commonUtils.logErrorOnce(err);

--- a/src/job.ts
+++ b/src/job.ts
@@ -15,6 +15,7 @@ export interface IJob {
     // android
     androidPackage?: string;
     buildMode?: ANDROID_BUILD_MODES;
+    gradleArgs?: string[];
   };
   credentials: {
     // android

--- a/src/jobsSchemas/android.ts
+++ b/src/jobsSchemas/android.ts
@@ -15,6 +15,7 @@ export default baseJobSchema.concat(
     config: Joi.object().keys({
       buildMode: Joi.string().valid(Object.values(ANDROID_BUILD_MODES)).default(ANDROID_BUILD_MODES.RELEASE),
       buildType: Joi.string().valid(Object.values(ANDROID_BUILD_TYPES)).default(ANDROID_BUILD_TYPES.APK),
+      gradleArgs: Joi.array().items(Joi.string()),
     }),
   }),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,10 +2064,10 @@
     workbox-webpack-plugin "^3.6.3"
     worker-loader "^2.0.0"
 
-"@expo/xdl@57.9.25-alpha.0":
-  version "57.9.25-alpha.0"
-  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-57.9.25-alpha.0.tgz#b5ecebea4ac9e567d25a0eb3dcfadb6a2405568a"
-  integrity sha512-Fvxga0DbS/qZVym2yUSg3Kf1tn2FpFqDbYi5M/yk7gZNMQITh6Ssv1Jib+WTpSL7cDR3M+GOAS7GuIy12Db+Iw==
+"@expo/xdl@57.9.25-alpha.1":
+  version "57.9.25-alpha.1"
+  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-57.9.25-alpha.1.tgz#1c96219b10f8214b9db623044d7e613c83b7bf25"
+  integrity sha512-EEsbxZUnwQVpsvZfcoLeVuI9e1R4bZpXXYU9Rx50PeahvBRzhFSYtZd5LBKcfhlQn6IhCNQU2JTyhYJGlJB6mw==
   dependencies:
     "@expo/bunyan" "3.0.2"
     "@expo/config" "3.2.15"


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

Closes https://github.com/expo/turtle/issues/226

### Description

I added a new `build:android` option: `--gradle-args`. It can be used to pass custom arguments to gradle, like `--stacktrace`.
