### PR TITLE
Update Android shell tarball for SDK38 with targetSdkVersion bumped to 29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Updated Android shell app for SDK 38 with `targetSdkVersion` bumped to 29. ([#244](https://github.com/expo/turtle/pull/244))
+
 ## [0.17.0] - 2020-07-16
 
 ### Added

--- a/shellTarballs/android/sdk38
+++ b/shellTarballs/android/sdk38
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-b2865cc77a643d5743f53c0042a6eff18e317760.tar.gz
+s3://exp-artifacts/android-shell-builder-6cde8e00cd7bdf7a933cd8aad7f8e86981ea68a2.tar.gz

--- a/shellTarballs/android/sdk38
+++ b/shellTarballs/android/sdk38
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-076a13fd8b4ee84a59eb6d2777f6db0a2c71fb6d.tar.gz
+s3://exp-artifacts/android-shell-builder-b2865cc77a643d5743f53c0042a6eff18e317760.tar.gz


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

See https://github.com/expo/expo/pull/9446 and https://forums.expo.io/t/google-api-level-29/41231.

### Description

Updated Android SDK38 tarball with project with updated `targetSdkVersion`.