### PR TITLE
Hardcode maximum heap size

### DIFF
--- a/k8s/android/turtle-deployment.template.yml
+++ b/k8s/android/turtle-deployment.template.yml
@@ -144,9 +144,9 @@ spec:
           - name: DISABLE_DEX_MAX_HEAP
             value: "true"
           - name: JAVA_OPTS
-            value: '-Xms2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseG1GC -XX:MaxRAMFraction=1'
+            value: '-Xms2048m -Xmx8192m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC'
           - name: GRADLE_OPTS
-            value: '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xms2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseG1GC -XX:MaxRAMFraction=1"'
+            value: '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xms2048m -Xmx8192m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC"'
           - name: REDIS_CA_CERTIFICATE
             value: '/var/run/config/redislabs-tls/redislabs_ca.pem'
         resources:

--- a/k8s/android/turtle-deployment.template.yml
+++ b/k8s/android/turtle-deployment.template.yml
@@ -144,9 +144,9 @@ spec:
           - name: DISABLE_DEX_MAX_HEAP
             value: "true"
           - name: JAVA_OPTS
-            value: '-Xms2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseG1GC'
+            value: '-Xms2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseG1GC -XX:MaxRAMFraction=1'
           - name: GRADLE_OPTS
-            value: '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xms2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseG1GC"'
+            value: '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xms2048m -XX:+HeapDumpOnOutOfMemoryError -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseG1GC -XX:MaxRAMFraction=1"'
           - name: REDIS_CA_CERTIFICATE
             value: '/var/run/config/redislabs-tls/redislabs_ca.pem'
         resources:


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

Builds started to fail with

```
Error occurred during initialization of VM
Initial heap size set to a larger value than the maximum heap size
Error: ./gradlew exited with non-zero code: 1
    at ChildProcess.completionListener (/app/turtle/node_modules/@expo/xdl/node_modules/@expo/spawn-async/build/spawnAsync.js:52:23)
    at Object.onceWrapper (events.js:418:26)
    at ChildProcess.emit (events.js:311:20)
    at ChildProcess.EventEmitter.emit (domain.js:482:12)
    at maybeClose (internal/child_process.js:1021:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:286:5)
    ...
    at spawnAsync (/app/turtle/node_modules/@expo/xdl/node_modules/@expo/spawn-async/build/spawnAsync.js:17:21)
    at spawnAsyncThrowError (/app/turtle/node_modules/@expo/xdl/build/detach/ExponentTools.js:201:45)
    at buildShellAppAsync (/app/turtle/node_modules/@expo/xdl/build/detach/AndroidShellApp.js:940:11)
    at async Object.createAndroidShellAppAsync (/app/turtle/node_modules/@expo/xdl/build/detach/AndroidShellApp.js:386:5)
    at async runShellAppBuilder (/app/turtle/build/builders/android.js:95:9)
    at async Object.buildAndroid [as android] (/app/turtle/build/builders/android.js:43:28)
    at async build (/app/turtle/build/jobManager.js:181:33)
    at async processJob (/app/turtle/build/jobManager.js:118:32)
    at async Object.doJob (/app/turtle/build/jobManager.js:49:5)
    at async main (/app/turtle/build/server.js:66:13)
```

### Description

Consulted and helped with by @wkozyra95 — removed experimental options that made maximum heap size being set to a low value. Hardcoded proper value.