### PR TITLE
[android] Always add expo-notifications for SDK >= 39 projects with android.enableDangerousExperimentalLeanBuilds enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Always add expo-notifications for SDK >= 39 projects with android.enableDangerousExperimentalLeanBuilds enabled.
+
 # [0.18.4] - 2020-10-06
 
 ### Fixed

--- a/src/builders/android.ts
+++ b/src/builders/android.ts
@@ -84,7 +84,7 @@ async function runShellAppBuilder(
   logger.info({ buildPhase: 'resolve native modules' }, 'Resolving universal modules dependencies');
   const packageJsonDependecies = _.get(manifest, 'dependencies');
   const enabledModules = _.get(manifest, 'android.enableDangerousExperimentalLeanBuilds')
-    ? await resolveNativeModules(workingDir, packageJsonDependecies)
+    ? await resolveNativeModules(workingDir, sdkVersion, packageJsonDependecies)
     : await resolveExplicitOptIn(workingDir, packageJsonDependecies);
 
   try {


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

Fixes https://github.com/expo/expo/issues/10569. I discussed this with @sjchmiela and we decided this was the most feasible solution.

### Description

I made `resolveNativeModules` also take a `sdkVersion` argument and if it is greater than or equal to 39.0.0 then we add the expo-notifications module.
