### PR TITLE
Fix Reanimated v2 not being configured in production mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix issues with Reanimated v2 in Android SDK 39 tarball.
+
 # [0.18.7] - 2020-10-23
 
 ### Fixed

--- a/shellTarballs/android/sdk39
+++ b/shellTarballs/android/sdk39
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-1fd35ae3121ff51d657c93598947c17276bcb392.tar.gz
+s3://exp-artifacts/android-shell-builder-d292dcd0cc277ab665957244a8b15b9981debd29.tar.gz


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

Apply https://github.com/expo/expo/pull/10807.

### Description
Fixes app crashing when using Reanimated v2.