### PR TITLE
[ios][shellApps] Rebuild all supported shellApps with Xcode 12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Rebuild iOS tarballs (SDK 36, 37, 38, 39, Ad-Hoc Client) with Xcode 12.1.
+
 # [0.18.9] - 2020-11-09
 
 ### Fixed

--- a/shellTarballs/ios/client
+++ b/shellTarballs/ios/client
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-expo-client-401ff3fb71a1350c00bd0886f7eb4fd462bdf0c0.tar.gz
+s3://exp-artifacts/ios-expo-client-0cad7c12b268c5734bf2a49b393f238b3867c811.tar.gz

--- a/shellTarballs/ios/sdk36
+++ b/shellTarballs/ios/sdk36
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-661a51216c2241dcfdd930517968cd1d0e0ee237.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-45161ed7abac2f3c0886b2bfc30434278dfa96db.tar.gz

--- a/shellTarballs/ios/sdk37
+++ b/shellTarballs/ios/sdk37
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-30eb0558ff6a77acf56bb045e98b84f6a5e1478a.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-af70b59bba0eecfe8881838235c1ee4436a84608.tar.gz

--- a/shellTarballs/ios/sdk38
+++ b/shellTarballs/ios/sdk38
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-6cde8e00cd7bdf7a933cd8aad7f8e86981ea68a2.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-fc0fd683530ae3608ddc195163b45d54b79f7e09.tar.gz

--- a/shellTarballs/ios/sdk39
+++ b/shellTarballs/ios/sdk39
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-798b04f87b8f1518a0eb4009578cb216963922f0.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-07a795c2ea43f185223a66da7a220e6cae7d232c.tar.gz

--- a/src/builders/ios/index.ts
+++ b/src/builders/ios/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import pick from 'lodash/pick';
 
+import spawnAsync from '@expo/spawn-async';
 import buildArchive from 'turtle/builders/ios/archive';
 import { createBuilderContext, IContext } from 'turtle/builders/ios/context';
 import buildSimulator from 'turtle/builders/ios/simulator';
@@ -51,6 +52,7 @@ async function initBuilder(ctx: IContext) {
     await fs.ensureDir(dir);
     await fs.chmod(dir, 0o755);
   }
+  await spawnAsync('sudo', ['xcrun', 'simctl', 'list']);
 }
 
 async function cleanup(ctx: IContext) {


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
### Motivation and Context

As `turtle v1` is going to use Xcode 12.1 we have to update all the iOS shellApps to be pre-build with the very Xcode version.

### Description

#### standalone shellApps:
- [x] sdk 36
- [x] sdk 37
- [x] sdk 38
- [x] sdk 39

#### AdHoc Client Shell App:
- [x] done
 