### PR TITLE
[iOS] Rebuild shell tarballs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed the iOS build using Xcode 12.1 by runnig `xcrun simctl list` before the build phase.
+- Rebuild iOS tarballs (SDK 36, 37, 38, 39, Ad-Hoc Client) with Xcode 12.1 containing iOS 14 image fix.
 
 # [0.19.0] - 2020-11-13
 

--- a/shellTarballs/ios/client
+++ b/shellTarballs/ios/client
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-expo-client-401ff3fb71a1350c00bd0886f7eb4fd462bdf0c0.tar.gz
+s3://exp-artifacts/ios-expo-client-4a9a038998f6be13e8a2900a95afbb9f96dd023d.tar.gz

--- a/shellTarballs/ios/sdk36
+++ b/shellTarballs/ios/sdk36
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-661a51216c2241dcfdd930517968cd1d0e0ee237.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-0983415327f49592d81f0bd3dc8c46a3572c19b0.tar.gz

--- a/shellTarballs/ios/sdk37
+++ b/shellTarballs/ios/sdk37
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-30eb0558ff6a77acf56bb045e98b84f6a5e1478a.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-df407aadb7208fc389564aed400c39263294eb76.tar.gz

--- a/shellTarballs/ios/sdk38
+++ b/shellTarballs/ios/sdk38
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-6cde8e00cd7bdf7a933cd8aad7f8e86981ea68a2.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-ba6ec1974977bebf8fd2db22a1c87f6a0b36ffa5.tar.gz

--- a/shellTarballs/ios/sdk39
+++ b/shellTarballs/ios/sdk39
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-798b04f87b8f1518a0eb4009578cb216963922f0.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-4a9a038998f6be13e8a2900a95afbb9f96dd023d.tar.gz


### PR DESCRIPTION
### Motivation and Context

- Accommodate https://github.com/expo/expo/pull/11052 in all shellApps.
- Rebuild iOS shellApps using Xcode 12.1.

### Description

#### standalone shellApps:
- [x] sdk 36
  https://app.circleci.com/pipelines/github/expo/expo/23938/workflows/6313d313-0862-4f91-a797-d2b88706f9ee/jobs/158924
- [x] sdk 37
  https://app.circleci.com/pipelines/github/expo/expo/23934/workflows/de1540f6-877a-41db-92b7-cbd1636fe165/jobs/158887
- [x] sdk 38 
    https://app.circleci.com/pipelines/github/expo/expo/23930/workflows/4b3f770f-e8a3-405f-a1b9-6319a97825e2/jobs/158862
- [x] sdk 39
  https://github.com/expo/expo/actions/runs/368338037

#### AdHoc Client Shell App:
- [x] https://github.com/expo/expo/actions/runs/368338493
 

## TODO

- [x] deploy to staging https://app.circleci.com/pipelines/github/expo/turtle/1089/workflows/68925c87-721c-4294-89bd-f6a5277d014f/jobs/3811
- [x] test on staging
- [ ] publish turtle
- [ ] deploy to production
