### PR TITLE
[iOS] Run 'xcrun simctl list' before build to prevent ibtool crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed the iOS build using Xcode 12.1 by runnig `xcrun simctl list` before the build phase.
+
 # [0.19.0] - 2020-11-13
 
 ### Changed

--- a/src/builders/ios/index.ts
+++ b/src/builders/ios/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import pick from 'lodash/pick';
 
+import spawnAsync from '@expo/spawn-async';
 import buildArchive from 'turtle/builders/ios/archive';
 import { createBuilderContext, IContext } from 'turtle/builders/ios/context';
 import buildSimulator from 'turtle/builders/ios/simulator';
@@ -51,6 +52,7 @@ async function initBuilder(ctx: IContext) {
     await fs.ensureDir(dir);
     await fs.chmod(dir, 0o755);
   }
+  await spawnAsync('sudo', ['xcrun', 'simctl', 'list']);
 }
 
 async function cleanup(ctx: IContext) {


### PR DESCRIPTION
### Motivation and Context

Bringing back https://github.com/expo/turtle/pull/273/commits/c54455543ea90c17488081e48c76cb8cf10802a3 (https://github.com/expo/turtle/pull/273) to enable Xcode 12.1 usage.

### Description

Build using Xcode 12.1 breaks with `ibtool` error, because it fails in finding simulator-related libs for some reason, even though simulators are available on the machine. Running `xcrun simctl list` before Xcode build seems to fix the problem with finding the libraries.
