### PR TITLE
Verify jq installation in scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Verify jq installation before proceeding with release ([#281](https://github.com/expo/turtle/pull/281)).
+
 # [0.20.0] - 2020-11-30
 
 - Add SDK 40 tarballs in preparation for SDK 40 beta

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,6 +2,12 @@
 
 set -eo pipefail
 
+if ! command -v jq &> /dev/null
+then
+    echo "jq is not installed and is required by the release script. Install it through homebrew or your package manager of choice."
+    exit
+fi
+
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 
 if [[ -z "$GITHUB_TOKEN" || -z "$CIRCLE_API_USER_TOKEN" ]]; then

--- a/scripts/releaseBeta.sh
+++ b/scripts/releaseBeta.sh
@@ -2,6 +2,12 @@
 
 set -eo pipefail
 
+if ! command -v jq &> /dev/null
+then
+    echo "jq is not installed and is required by the release script. Install it through homebrew or your package manager of choice."
+    exit
+fi
+
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 
 $ROOT_DIR/node_modules/.bin/release-it -c $ROOT_DIR/.release-it.beta.json --preRelease=beta

--- a/scripts/updateTurtleCliExampleRepo.sh
+++ b/scripts/updateTurtleCliExampleRepo.sh
@@ -2,6 +2,12 @@
 
 set -eo pipefail
 
+if ! command -v jq &> /dev/null
+then
+    echo "jq is not installed and is required by the release script. Install it through homebrew or your package manager of choice."
+    exit
+fi
+
 DEPLOY_ENDPOINT_URL="https://circleci.com/api/v1.1/project/github/expo/turtle-cli-example/tree/updates-do-not-remove-me"
 
 curl -X POST \


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

I went to deploy a release from a relatively fresh machine and ended up in this state:

```
⠙ yarn release:update:turtle-cli-example
$ ./scripts/updateTurtleCliExampleRepo.sh
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
✖ yarn release:update:turtle-cli-example
ERROR ./scripts/updateTurtleCliExampleRepo.sh: line 17: jq: command not found
error Command failed with exit code 127.

Rolling back changes...
error Command failed with exit code 1.
```

It was pretty unclear how I could recover from this, and so it's best to avoid getting into this state if possible.

### Description

I added some verification that the `jq` executable is available and bail out if not.