### PR TITLE
Fixed the iOS build when user does not have elevated permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the iOS build when user does not have elevated permissions
+
 # [0.20.0] - 2020-11-30
 
 - Add SDK 40 tarballs in preparation for SDK 40 beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the iOS build when user does not have elevated permissions
+- Fixed the iOS build when running offline and user lacks elevated permissions.
 
 # [0.20.0] - 2020-11-30
 

--- a/src/builders/ios/index.ts
+++ b/src/builders/ios/index.ts
@@ -52,7 +52,7 @@ async function initBuilder(ctx: IContext) {
     await fs.ensureDir(dir);
     await fs.chmod(dir, 0o755);
   }
-  await spawnAsync('sudo', ['xcrun', 'simctl', 'list']);
+  await spawnAsync('xcrun', ['simctl', 'list']);
 }
 
 async function cleanup(ctx: IContext) {

--- a/src/builders/ios/index.ts
+++ b/src/builders/ios/index.ts
@@ -52,7 +52,13 @@ async function initBuilder(ctx: IContext) {
     await fs.ensureDir(dir);
     await fs.chmod(dir, 0o755);
   }
-  await spawnAsync('xcrun', ['simctl', 'list']);
+
+  if (config.builder.mode === 'online') {
+    await spawnAsync('sudo', ['xcrun', 'simctl', 'list']);
+  } else {
+    // sudo not needed for CLI builds
+    await spawnAsync('xcrun', ['simctl', 'list']);
+  }
 }
 
 async function cleanup(ctx: IContext) {


### PR DESCRIPTION
The use of sudo does not appear to be necessary to execute 'xcrun simctl list'.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
In our build environment the user running turtle does not have elevated permissions. We performed all the setup steps using an administrative account, but have a dedicated, limited user account for the actual CI builds we perform using Jenkins.

We had no troubles with our build prior to release 0.19.1, which introduced a fix for building with Xcode 12.1. Following this release, our builds started failing. Perhaps it is just our environment, but we have no issues executing xcrun without elevated permissions. At this point we are building with Xcode 12.2 successfully using this change.

### Description
Removed the use of 'sudo' to run 'xcrun simctl list' as introduced by #279.
We tested this patch in place by updating the javascript from package freshly-installed via yarn and executing our build job, which did not overwrite the updated package code. We checked that the build succeeded, and confirmed that the JS we edited was not overwritten by a fresh copy of the package in the process of the build.