### PR TITLE
[ios] Fix expo-notifications initial notification not being delivered…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Updated SDK 40 iOS tarball to fix `expo-notifications` not emitting initial notification response.
+
 # [0.20.3] - 2020-12-10
 
 ### Fixed

--- a/shellTarballs/ios/sdk40
+++ b/shellTarballs/ios/sdk40
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-5a9fa62b9ba6a67e081281ebd1fbe57c3baa92b7.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-005911cfc5c406f94bc274393c1a4c972145889b.tar.gz

--- a/shellTarballs/ios/sdk40
+++ b/shellTarballs/ios/sdk40
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-c49a0464aef589dc9dd691cea78313d91959d64c.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-18350107fd109999f0ab5caabe45a4a92348da9d.tar.gz

--- a/shellTarballs/ios/sdk40
+++ b/shellTarballs/ios/sdk40
@@ -1,1 +1,1 @@
-s3://exp-artifacts/ios-shell-builder-sdk-latest-005911cfc5c406f94bc274393c1a4c972145889b.tar.gz
+s3://exp-artifacts/ios-shell-builder-sdk-latest-c49a0464aef589dc9dd691cea78313d91959d64c.tar.gz


### PR DESCRIPTION
 to expo-notifications

<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
Adds https://github.com/expo/expo/commit/0e0bbdd7b45b3e8f8725bcd831263f049c0aa16a and https://github.com/expo/expo/commit/c49a0464aef589dc9dd691cea78313d91959d64c fixing long-standing notifications bug.
