### PR TITLE
[android] Upgrade to client 2.18.5 with background permission fix

### DIFF
--- a/shellTarballs/android/sdk40
+++ b/shellTarballs/android/sdk40
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-8d2e78959cfe6c39deac929279e709c4b7b91ec4.tar.gz
+s3://exp-artifacts/android-shell-builder-4ae9f373059baabac079218f6fa0b5c5c929a152.tar.gz


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] ~~I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.~~
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
This version contains [PR #11399](https://github.com/expo/expo/pull/11399) to fix android background permissions check for Android <9.

### Description
- Includes [PR #11399](https://github.com/expo/expo/pull/11399)
- Backported [to `sdk-40` branch](https://github.com/expo/expo/commit/d07eaeb668cf1132d7e8e49da2ccb0c449a1a81f)
- Generated [from this workflow](https://github.com/expo/expo/runs/1597378742)
