### PR TITLE
increase android worker memory and cpu limits

### DIFF
--- a/k8s/android/turtle-deployment.template.yml
+++ b/k8s/android/turtle-deployment.template.yml
@@ -144,15 +144,15 @@ spec:
           - name: DISABLE_DEX_MAX_HEAP
             value: "true"
           - name: JAVA_OPTS
-            value: '-Xms2048m -Xmx8192m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC'
+            value: '-Xms2048m -Xmx10g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC'
           - name: GRADLE_OPTS
-            value: '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xms2048m -Xmx8192m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC"'
+            value: '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xms2048m -Xmx10g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC"'
           - name: REDIS_CA_CERTIFICATE
             value: '/var/run/config/redislabs-tls/redislabs_ca.pem'
         resources:
           requests:
-            memory: "8192Mi"
+            memory: "9Gi"
             cpu: "2000m"
           limits:
-            memory: "8192Mi"
-            cpu: "2000m"
+            memory: "10Gi"
+            cpu: "3000m"


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

https://linear.app/expo/issue/ENG-895/investigate-occasionally-failing-builds-on-turtle-android

### Description

Increase memory limits on k8s and for JVM
For k8s i set `request` to 9GB and limit to 10GB, because the host has 30 GB and I want to make sure that 3 pods could  be scheduled on host
