### PR TITLE
[logger] Fix s3 logger stream close crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix s3 logger stream close crash.
+
 # [0.22.4] - 2021-07-27
 
 - Update iOS and Android tarballs for SDK 42.

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -29,13 +29,13 @@ class Logger {
       jobID: job.id,
       experienceName: job.experienceName,
     });
-    const s3Url = await streams.s3.stream.init(job);
+    const s3Url = await streams.s3?.stream.init(job);
     return s3Url;
   }
 
   public async cleanup() {
     this.currentLogger = this.parentLogger;
-    await streams.s3.stream.cleanup();
+    await streams.s3?.stream.cleanup();
   }
 
   public trace(...all: any[]) {

--- a/src/logger/streams/index.ts
+++ b/src/logger/streams/index.ts
@@ -1,20 +1,22 @@
-import pickBy from 'lodash/pickBy';
-
+import { pickBy } from 'lodash';
 import createGCloudStream from 'turtle/logger/streams/gcloud';
 import createOfflineStream from 'turtle/logger/streams/offline';
-import createS3Stream from 'turtle/logger/streams/s3';
+import createS3Stream, { S3Stream } from 'turtle/logger/streams/s3';
 import createSentryStream from 'turtle/logger/streams/sentry';
 import { isOffline } from 'turtle/turtleContext';
 
-interface IStream {
-  stream: any;
+interface IStream<T> {
+  stream: T;
   type?: string;
   level?: string;
   reemitErrorEvents?: boolean;
 }
 
 interface IStreamMap {
-  [key: string]: IStream;
+  stdout: IStream<any>;
+  gcloud?: IStream<any>;
+  s3?: IStream<S3Stream>;
+  sentry?: IStream<any>;
 }
 
 function prepareStreams(): IStreamMap {
@@ -29,7 +31,7 @@ function prepareStreams(): IStreamMap {
       s3: createS3Stream(),
       sentry: createSentryStream(),
     };
-    return pickBy(allStreams) as IStreamMap;
+    return pickBy(allStreams) as any as IStreamMap;
   }
 }
 

--- a/src/logger/streams/s3.ts
+++ b/src/logger/streams/s3.ts
@@ -18,7 +18,7 @@ export default function create() {
   };
 }
 
-class S3Stream extends EventEmitter {
+export class S3Stream extends EventEmitter {
   private s3Url: string | null = null;
   private lastFlush: number | null = null;
   private filePath: string | null = null;
@@ -44,7 +44,11 @@ class S3Stream extends EventEmitter {
 
   public async cleanup() {
     await this.flush(true);
-    await fs.close(this.fileHandle as number);
+
+    if (this.fileHandle) {
+      await fs.close(this.fileHandle);
+    }
+
     this.fileHandle = null;
     this.waitingOnPromise = false;
   }
@@ -64,7 +68,7 @@ class S3Stream extends EventEmitter {
       return;
     }
     fs
-      .write(this.fileHandle as number, `${JSON.stringify(rec)}\n`)
+      .write(this.fileHandle, `${JSON.stringify(rec)}\n`)
       .then(() => {
         this.flush();
       });


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [x] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

https://sentry.io/organizations/expoio/issues/1592626714/?project=1215772&query=is%3Aunresolved

### Description

This crash occurred when this other crash occurred: https://sentry.io/organizations/expoio/issues/1590618351/?project=1215772&query=is%3Aunresolved
