### PR TITLE
redirect google bintray url to localhost

### DIFF
--- a/src/builders/android.ts
+++ b/src/builders/android.ts
@@ -17,7 +17,15 @@ import config from 'turtle/config';
 import { IAndroidCredentials, IJob, IJobResult } from 'turtle/job';
 import logger from 'turtle/logger';
 
+// temporary solution until we can rebuild shellapps
+const blockGoogleBintrayAsync = _.once(async () => {
+  if (config.builder.mode === 'online') {
+    await fs.appendFile('/etc/hosts', '\n127.0.0.1\tdl.bintray.com\n127.0.0.1\tgoogle.bintray.com\n');
+  }
+});
+
 export default async function buildAndroid(jobData: IJob): Promise<IJobResult> {
+  await blockGoogleBintrayAsync();
   await ensureCanBuildSdkVersion(jobData);
   const credentials = await getOrCreateCredentials(jobData);
   const outputFilePath = await runShellAppBuilder(jobData, credentials);


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

google bintray went down and returns 502 errors, which immediately is causing gradle scripts to fail. Redirecting it to localhost will force gradle to check other registries before erroring which should work for most if not all supported sdks

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
