### PR TITLE
[android] Update android shell tarballs for bintray error fix

### DIFF
--- a/shellTarballs/android/sdk40
+++ b/shellTarballs/android/sdk40
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-b111c38c47a05d1c340c69e8744fe0832b05634b.tar.gz
+s3://exp-artifacts/android-shell-builder-da0e85b79332cb8e93178aefcd90f7450e6e923e.tar.gz

--- a/shellTarballs/android/sdk41
+++ b/shellTarballs/android/sdk41
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-ee6c4df8486ae4995e50e4d398ba0ef41a097cfe.tar.gz
+s3://exp-artifacts/android-shell-builder-a7bb029adbc5636ac738759d70d80cc0f90dd757.tar.gz

--- a/shellTarballs/android/sdk42
+++ b/shellTarballs/android/sdk42
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-52041fd6957e7f34d0d0b96e3790570f95de4bd7.tar.gz
+s3://exp-artifacts/android-shell-builder-8725597cdf885f3d34cbbd7f74c6d1e0b9c31c93.tar.gz

--- a/shellTarballs/android/sdk43
+++ b/shellTarballs/android/sdk43
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-8a45d6d743b91f608f0548d2ab02a3cef7434dcf.tar.gz
+s3://exp-artifacts/android-shell-builder-fe8aed82dd482644ed51d0dc45ae82c4c40a55c1.tar.gz

--- a/src/builders/android.ts
+++ b/src/builders/android.ts
@@ -17,15 +17,7 @@ import config from 'turtle/config';
 import { IAndroidCredentials, IJob, IJobResult } from 'turtle/job';
 import logger from 'turtle/logger';
 
-// temporary solution until we can rebuild shellapps
-const blockGoogleBintrayAsync = _.once(async () => {
-  if (config.builder.mode === 'online') {
-    await fs.appendFile('/etc/hosts', '\n127.0.0.1\tdl.bintray.com\n127.0.0.1\tgoogle.bintray.com\n');
-  }
-});
-
 export default async function buildAndroid(jobData: IJob): Promise<IJobResult> {
-  await blockGoogleBintrayAsync();
   await ensureCanBuildSdkVersion(jobData);
   const credentials = await getOrCreateCredentials(jobData);
   const outputFilePath = await runShellAppBuilder(jobData, credentials);


### PR DESCRIPTION
### Checklist
- [ ] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

fix android gradle build errors for dl.bintray.com and google.bintray.com return http 502.

### Description

apply https://github.com/expo/expo/pull/15349 to sdk 40-43 shell apps.
i did not verify the new shell apps yet, will do it after deploying to staging.

### Discussion

do we need to backport the fix to older sdks for sdk36 - sdk39?

