### PR TITLE
[builder] Resolve modules by either unimodule.json or expo-module.config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Update iOS and Android tarballs for SDK 44 beta.
+- Add detection for Expo modules using `expo-module.config.json`, the successor to `unimodule.json`. [#368](https://github.com/expo/turtle/pull/368).
 
 # [0.23.5] - 2021-11-12
 

--- a/src/builders/utils/unimodules.ts
+++ b/src/builders/utils/unimodules.ts
@@ -209,7 +209,9 @@ async function getPackage(
   const pkgPath = path.join(workingdir, 'packages', pkgName);
   const isAndroid = await fs.pathExists(path.join(pkgPath, 'android'));
   const isIos = await fs.pathExists(path.join(pkgPath, 'ios'));
-  const isUnimodule = await fs.pathExists(path.join(pkgPath, 'unimodule.json'));
+  const isUnimodule =
+    (await fs.pathExists(path.join(pkgPath, 'unimodule.json'))) ||
+    (await fs.pathExists(path.join(pkgPath, 'expo-module.config.json')));
   const hasPackageJson = await fs.pathExists(
     path.join(pkgPath, 'package.json'),
   );


### PR DESCRIPTION
### Checklist
- [ ] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

Currently on SDK 44 beta we're not including expo-updates in builds.

### Description

The issue appears to be that we renamed **unimodule.json** to **expo-module.config.json** and we currently resolve modules by looking for **unimodule.json** only (h/t @esamelson for spotting this).