### PR TITLE
switch cloudfront domain to classic-assets.eascdn.net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Swap out Cloudfront CDN for `classic-assets.eascdn.net`. [#375](https://github.com/expo/turtle/pull/375)
+
 # [0.24.3] - 2021-12-29
 
 - Update ios sdk 44 shell tarball with [orientation lock fix](https://github.com/expo/expo/pull/15715)

--- a/src/__tests__/fixtures/iosJob.json
+++ b/src/__tests__/fixtures/iosJob.json
@@ -83,7 +83,7 @@
        ],
        "description": "A very interesting project.",
        "icon": "./assets/images/icon.png",
-       "iconUrl": "https://d1wp6m56sqw74a.cloudfront.net/~assets/fa6577fecc0a7838f15a254577639984",
+       "iconUrl": "https://classic-assets.eascdn.net/~assets/fa6577fecc0a7838f15a254577639984",
        "ios": {
           "bundleIdentifier": "com.niech.to.zadziala",
           "supportsTablet": true
@@ -101,7 +101,7 @@
        "splash": {
           "backgroundColor": "#ffffff",
           "image": "./assets/images/splash.png",
-          "imageUrl": "https://d1wp6m56sqw74a.cloudfront.net/~assets/43ec0dcbe5a156bf9e650bb8c15e7af6",
+          "imageUrl": "https://classic-assets.eascdn.net/~assets/43ec0dcbe5a156bf9e650bb8c15e7af6",
           "resizeMode": "contain"
        },
        "updates": {
@@ -112,7 +112,7 @@
        "revisionId": "1.0.0-r.zV1W89wn23",
        "publishedTime": "2018-10-16T08:44:05.362Z",
        "commitTime": "2018-10-16T08:44:05.403Z",
-       "bundleUrl": "https://d1wp6m56sqw74a.cloudfront.net/%40admin%2FtestApp%2F1.0.0%2Fb8678e2be7cd5bb9e240db0dd3c691c0-29.0.0-ios.js",
+       "bundleUrl": "https://classic-assets.eascdn.net/%40admin%2FtestApp%2F1.0.0%2Fb8678e2be7cd5bb9e240db0dd3c691c0-29.0.0-ios.js",
        "releaseChannel": "default",
        "hostUri": "exp.host/@admin/testApp"
     },


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This PR swaps out the hard coded `d1wp6m56sqw74a.cloudfront.net` cdn with `classic-assets.eascdn.net`

Replacing domains will help us gradually shift traffic away from CloudFront to Cloudflare if we wanted to. However, we make assumptions, including in shipped client code in end-user apps, about https://d1wp6m56sqw74a.cloudfront.net. 

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
