### PR TITLE
Switch to JDK 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # see docker-base/Dockerfile to learn what's installed in the turtle-android-base image
-FROM gcr.io/exponentjs/turtle-android-base:0.6.0
+FROM gcr.io/exponentjs/turtle-android-base:0.7.0
 
 ADD . /app/turtle
 

--- a/docker-base/Dockerfile
+++ b/docker-base/Dockerfile
@@ -1,6 +1,6 @@
 # If you ever need to rebuild this, run:
 # yarn docker:build-and-push:android-base-image NEW_IMAGE_SEMVER
-FROM openjdk:8u141
+FROM openjdk:11.0.14.1-jdk
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -18,7 +18,6 @@ RUN dpkg --add-architecture i386 && \
   bzip2:i386\
   file\
   jq\
-  lib32ncurses5\
   lib32z1\
   libc6:i386\
   libncurses5:i386\
@@ -41,14 +40,11 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
 # Download and untar SDK
 ENV ANDROID_HOME /usr/local/android-sdk-linux
 ENV ANDROID_SDK /usr/local/android-sdk-linux
-ENV ANDROID_SDK_URL https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
-RUN mkdir -p ${ANDROID_HOME} && \
-  curl -L "${ANDROID_SDK_URL}" > ${ANDROID_HOME}/sdk.zip && \
-  cd ${ANDROID_HOME} && \
-  unzip -qq sdk.zip && \
-  rm sdk.zip && \
-  mkdir -p ${HOME}/.android && \
-  touch ${HOME}/.android/repositories.cfg
+RUN curl -s https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip > /tmp/tools.zip && \
+  mkdir -p $ANDROID_HOME/cmdline-tools && \
+  unzip -q -d $ANDROID_HOME/cmdline-tools /tmp/tools.zip && \
+  mv $ANDROID_HOME/cmdline-tools/cmdline-tools $ANDROID_HOME/cmdline-tools/tools && \
+  rm /tmp/tools.zip
 
 ENV PATH ${ANDROID_HOME}/platform-tools:${PATH}
 ENV PATH ${ANDROID_HOME}/tools:${PATH}

--- a/scripts/android/configureAndroidSdk.sh
+++ b/scripts/android/configureAndroidSdk.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SDKMANAGER=$ANDROID_HOME/tools/bin/sdkmanager
+SDKMANAGER=$ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager
 
 yes | $SDKMANAGER --licenses > /dev/null
 if [[ "$1" = "--install-all-platforms" ]]; then

--- a/src/bin/setup/android/index.ts
+++ b/src/bin/setup/android/index.ts
@@ -14,7 +14,6 @@ import { PLATFORMS } from 'turtle/constants';
 import logger from 'turtle/logger';
 
 const which = util.promisify(_which);
-const JAVA_REQUIRED_VERSION = 8;
 const REQUIRED_TOOLS: IToolDefinition[] = [
   {
     command: 'bash',
@@ -23,9 +22,9 @@ const REQUIRED_TOOLS: IToolDefinition[] = [
   {
     command: 'javac',
     missingDescription:
-      `Please install JDK 8 - keep in mind that other versions are not supported by Android`,
+      `Please install JDK 11 - keep in mind that other versions might not be supported by Android`,
     testFn: async () => {
-      const { status, stdout, stderr } = await ExponentTools.spawnAsyncThrowError(
+      const { status, stdout } = await ExponentTools.spawnAsyncThrowError(
         'java',
         ['-version'],
         { stdio: 'pipe' },
@@ -33,19 +32,6 @@ const REQUIRED_TOOLS: IToolDefinition[] = [
       if (stdout.match(/no java runtime present/i)) {
         return false;
       }
-
-      const matchResult = stderr.match(/.*version "(.*)"/);
-      if (matchResult) {
-        const [, currentFullJavaVersion] = matchResult;
-        const javaMajorVersionPosition = currentFullJavaVersion.startsWith('1.') ? 1 : 0;
-        const javaMajorVersion = Number(currentFullJavaVersion.split('.')[javaMajorVersionPosition]);
-        if (javaMajorVersion !== JAVA_REQUIRED_VERSION) {
-          throw new Error(`You're on Java ${currentFullJavaVersion}, please install version ${JAVA_REQUIRED_VERSION}`);
-        }
-      } else {
-        logger.warn(`Couldn't find Java version number, assuming you're on Java ${JAVA_REQUIRED_VERSION}...`);
-      }
-
       return status === 0;
     },
   },

--- a/src/bin/setup/android/sdk.ts
+++ b/src/bin/setup/android/sdk.ts
@@ -18,7 +18,7 @@ const l = logger.child(LOGGER_FIELDS);
 export default async function ensureAndroidSDKIsPresent() {
   const androidSdkDir = path.join(config.directories.androidDependenciesDir, 'sdk');
   const readyFileName = '.ready-v2';
-  await utils.removeDirectoryUnlessReady(androidSdkDir, undefined, readyFileName);
+  await utils.removeDirectoryUnlessReady(androidSdkDir, { readyFileName });
   if (!(await fs.pathExists(androidSdkDir))) {
     await fs.ensureDir(androidSdkDir);
     const androidSdkDownloadPath = utils.formatArtifactDownloadPath(ANDROID_SDK_URL);
@@ -34,7 +34,7 @@ export default async function ensureAndroidSDKIsPresent() {
       await fs.remove(androidSdkDownloadPath);
       l.info('Configuring Android SDK, this may take a while');
       await _configureSdk(androidSdkDir);
-      await utils.markDirectoryAsReady(androidSdkDir, undefined, readyFileName);
+      await utils.markDirectoryAsReady(androidSdkDir, { readyFileName });
       l.info('Android SDK installed and configured successfully');
     } catch (err) {
       await fs.remove(androidSdkDir);

--- a/src/bin/setup/utils/common.ts
+++ b/src/bin/setup/utils/common.ts
@@ -30,7 +30,7 @@ export async function ensureShellAppIsPresent(
 ) {
   const workingdir = formatters.formatShellAppDirectory({ sdkVersion });
   const shellAppMetadata = await _readShellAppTarballS3Uri(sdkVersion, formatters);
-  await removeDirectoryUnlessReady(workingdir, shellAppMetadata);
+  await removeDirectoryUnlessReady(workingdir, { metadata: shellAppMetadata });
   if (await fs.pathExists(workingdir)) {
     return;
   }
@@ -39,7 +39,7 @@ export async function ensureShellAppIsPresent(
   if (postDownloadAction) {
     await postDownloadAction(sdkVersion, workingdir);
   }
-  await markDirectoryAsReady(workingdir, shellAppMetadata);
+  await markDirectoryAsReady(workingdir, { metadata: shellAppMetadata });
 }
 
 async function _downloadShellApp(sdkVersion: string, targetDirectory: string, formatters: IShellAppFormaters) {
@@ -69,7 +69,10 @@ async function _readShellAppTarballS3Uri(sdkVersion: string, formatters: IShellA
   return data.trim();
 }
 
-export async function removeDirectoryUnlessReady(dir: string, metadata?: string, readyFileName?: string) {
+export async function removeDirectoryUnlessReady(
+  dir: string,
+  { metadata, readyFileName }: { metadata?: string, readyFileName?: string },
+) {
   const readyFilePath = path.join(dir, readyFileName ?? '.ready');
   const readyFileExists = await fs.pathExists(readyFilePath);
   let shouldRemove = false;
@@ -78,7 +81,7 @@ export async function removeDirectoryUnlessReady(dir: string, metadata?: string,
       const readyFileContents = (await fs.readFile(readyFilePath, 'utf-8')).trim();
       if (readyFileContents !== metadata) {
         shouldRemove = true;
-       }
+      }
     }
   } else {
     shouldRemove = true;
@@ -88,7 +91,10 @@ export async function removeDirectoryUnlessReady(dir: string, metadata?: string,
   }
 }
 
-export async function markDirectoryAsReady(dir: string, metadata?: string, readyFileName?: string) {
+export async function markDirectoryAsReady(
+  dir: string,
+  { metadata, readyFileName }: { metadata?: string, readyFileName?: string },
+) {
   const readyFilePath = path.join(dir, readyFileName ?? '.ready');
   if (metadata === undefined) {
     await fs.open(readyFilePath, 'w');

--- a/src/bin/setup/utils/common.ts
+++ b/src/bin/setup/utils/common.ts
@@ -17,7 +17,7 @@ interface IShellAppFormaters {
   formatShellAppTarballUriPath: (sdkMajorVersion: string) => string;
 }
 
-type PostDownloadAction = (sdkVersion: string, workingdir: string) => void;
+type PostDownloadAction = (sdkVersion: string, workingdir: string) => Promise<void>;
 
 export async function checkSystem(requiredTools: IToolDefinition[]) {
   await ensureToolsAreInstalled(requiredTools);
@@ -69,8 +69,8 @@ async function _readShellAppTarballS3Uri(sdkVersion: string, formatters: IShellA
   return data.trim();
 }
 
-export async function removeDirectoryUnlessReady(dir: string, metadata?: string) {
-  const readyFilePath = path.join(dir, '.ready');
+export async function removeDirectoryUnlessReady(dir: string, metadata?: string, readyFileName?: string) {
+  const readyFilePath = path.join(dir, readyFileName ?? '.ready');
   const readyFileExists = await fs.pathExists(readyFilePath);
   let shouldRemove = false;
   if (readyFileExists) {
@@ -88,8 +88,8 @@ export async function removeDirectoryUnlessReady(dir: string, metadata?: string)
   }
 }
 
-export async function markDirectoryAsReady(dir: string, metadata?: string) {
-  const readyFilePath = path.join(dir, '.ready');
+export async function markDirectoryAsReady(dir: string, metadata?: string, readyFileName?: string) {
+  const readyFilePath = path.join(dir, readyFileName ?? '.ready');
   if (metadata === undefined) {
     await fs.open(readyFilePath, 'w');
   } else {


### PR DESCRIPTION
<!-- Thanks for contributing to _turtle_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- [ ] I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [ ] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [ ] **I've manually tested whether the changes I made work as expected.**

### Motivation and Context

Next SDK will require jdk11

### Description

Remove requirement for jdk8 from turtle-cli
Install jdk 11 for cloud builds

Tested sdk-44 with turtle-cli
Tested on staing with all sdk from 44 to 39 (for older ones I was not able to publish the bundle on init project)
