### PR TITLE
Update android sdk 45 tarball to fix build errors

### DIFF
--- a/shellTarballs/android/sdk45
+++ b/shellTarballs/android/sdk45
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-98e9664e2c37baa2b71a8bc3c43f8f9e24a391c3.tar.gz
+s3://exp-artifacts/android-shell-builder-db5944cfc76c9bb878f2b300405f93ecad8d6cec.tar.gz

--- a/shellTarballs/android/sdk45
+++ b/shellTarballs/android/sdk45
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-e9f61e8833ada706ce808bdededee85e2a1cd8af.tar.gz
+s3://exp-artifacts/android-shell-builder-fc8e8f712075f42bbbc21c4fc432e270531d16cf.tar.gz

--- a/shellTarballs/android/sdk45
+++ b/shellTarballs/android/sdk45
@@ -1,1 +1,1 @@
-s3://exp-artifacts/android-shell-builder-db5944cfc76c9bb878f2b300405f93ecad8d6cec.tar.gz
+s3://exp-artifacts/android-shell-builder-e9f61e8833ada706ce808bdededee85e2a1cd8af.tar.gz


### PR DESCRIPTION
### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/expo/turtle/blob/master/CONTRIBUTING.md).
- n/a I've updated the [CHANGELOG](https://github.com/expo/turtle/blob/master/CHANGELOG.md) if necessary.
- [x] I've ensured the unit and smoke tests are still passing - either by running `yarn test:unit` and `yarn test:smoke:[ios|android]` or by checking the appropriate CircleCI builds' statuses.
- [x] **I've manually tested whether the changes I made work as expected.**

### Description

fix the android build errors where react-native-gradle-plugin is not found
basically the change is covered in this pr: https://github.com/expo/expo/pull/17616
